### PR TITLE
Instead of splitting Markdowns into small nostr

### DIFF
--- a/src/Data.tsx
+++ b/src/Data.tsx
@@ -21,6 +21,7 @@ import {
   KIND_VIEWS,
   KIND_SETTINGS,
   KIND_DELETE,
+  KIND_KNOWLEDGE_NODE_COLLECTION,
 } from "./nostr";
 import { useApis } from "./Apis";
 import {
@@ -54,6 +55,7 @@ const KINDS_CONTACTS = [
   KIND_RELATION_TYPES,
   KIND_KNOWLEDGE_LIST,
   KIND_KNOWLEDGE_NODE,
+  KIND_KNOWLEDGE_NODE_COLLECTION,
   KIND_DELETE,
 ];
 

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -11,11 +11,7 @@ import { RemoveColumnButton } from "./RemoveColumnButton";
 import { upsertRelations, useViewKey, useViewPath } from "../ViewContext";
 import { TreeView } from "./TreeView";
 import { AddNodeToNode } from "./AddNode";
-import {
-  planBulkUpsertNodes,
-  planBulkUpsertRelations,
-  usePlanner,
-} from "../planner";
+import { Plan, usePlanner } from "../planner";
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable @typescript-eslint/unbound-method */
@@ -23,23 +19,12 @@ export function Column(): JSX.Element | null {
   const viewContext = useViewPath();
   const deselectByPostfix = useDeselectAllInView();
   const viewKey = useViewKey();
-  const { createPlan, executePlan } = usePlanner();
-  const onDropFiles = (
-    nodes: KnowNode[],
-    relations: Relations[],
-    topNodes: Array<LongID>
-  ): void => {
-    const bulkUpsertPlan = planBulkUpsertNodes(createPlan(), nodes);
-    const addTopNodesPlan = upsertRelations(
-      bulkUpsertPlan,
-      viewContext,
-      (r: Relations) => bulkAddRelations(r, topNodes)
+  const { executePlan } = usePlanner();
+  const onDropFiles = (plan: Plan, topNodes: Array<LongID>): void => {
+    const addTopNodesPlan = upsertRelations(plan, viewContext, (r: Relations) =>
+      bulkAddRelations(r, topNodes)
     );
-    const addRelationsPlan = planBulkUpsertRelations(
-      addTopNodesPlan,
-      relations
-    );
-    executePlan(addRelationsPlan);
+    executePlan(addTopNodesPlan);
     deselectByPostfix(viewKey);
   };
 

--- a/src/components/FileDropZone.tsx
+++ b/src/components/FileDropZone.tsx
@@ -2,9 +2,18 @@ import React from "react";
 import { useDropzone } from "react-dropzone";
 import MarkdownIt from "markdown-it";
 
-import { newNode, bulkAddRelations } from "../connections";
+import { v4 } from "uuid";
+import { Map } from "immutable";
+import { Event } from "nostr-tools";
+import {
+  finalizeEvent,
+  KIND_KNOWLEDGE_NODE_COLLECTION,
+  newTimestamp,
+} from "../nostr";
+import { newNode, bulkAddRelations, shortID } from "../connections";
 import { newRelations } from "../ViewContext";
-import { useData } from "../DataContext";
+import { Plan, planUpsertRelations, usePlanner } from "../planner";
+import { newDB } from "../knowledge";
 
 /* eslint-disable functional/immutable-data */
 function convertToPlainText(html: string): string {
@@ -14,46 +23,111 @@ function convertToPlainText(html: string): string {
 }
 /* eslint-enable functional/immutable-data */
 
-function createSourceFromParagraphs(
-  paragraphs: Array<string>,
+function createRelationsFromParagraphNodes(
+  nodes: KnowNode[],
   myself: PublicKey
-): {
-  nodes: KnowNode[];
-  relations: Relations;
-  topNodeID: LongID;
-} {
-  const topParagraph = paragraphs[0];
-  const furtherParagraphs = paragraphs.slice(1);
-
-  const topNode = newNode(topParagraph, myself);
-  const innerNodes = furtherParagraphs.map((paragraph) => {
-    return newNode(paragraph, myself);
-  });
+): [relations: Relations, topNodeID: LongID] {
+  const topParagraph = nodes[0];
+  const furtherParagraphs = nodes.slice(1);
   const relations = bulkAddRelations(
-    newRelations(topNode.id, "", myself),
-    innerNodes.map((n) => n.id)
+    newRelations(topParagraph.id, "", myself),
+    furtherParagraphs.map((n) => n.id)
   );
-  const nodes = [topNode, ...innerNodes];
-  return {
+  return [relations, topParagraph.id];
+}
+
+export function createNodesFromMarkdown(
+  markdown: string,
+  baseID: string,
+  myself: PublicKey
+): KnowNode[] {
+  const markdownParagraphs = markdown.split("\n\n");
+  const plainTextParagraphs = markdownParagraphs.map((paragraph: string) => {
+    const md = new MarkdownIt();
+    return convertToPlainText(md.render(paragraph));
+  });
+  return plainTextParagraphs.map((paragraph, index) => {
+    return newNode(paragraph, myself, `${baseID}${index}`);
+  });
+}
+
+const CHUNK_SIZE = 8196;
+
+function splitMarkdownInChunkSizes(markdown: string): string[] {
+  const paragraphs = markdown.split("\n\n");
+  return paragraphs.reduce((rdx: string[], p: string, i: number): string[] => {
+    const currentChunk = rdx[rdx.length - 1] || "";
+
+    const paragraph = i === paragraphs.length - 1 ? p : `${p}\n\n`;
+    if (currentChunk.length + paragraph.length > CHUNK_SIZE) {
+      return [...rdx, paragraph];
+    }
+    return [...rdx.slice(0, -1), `${currentChunk}${paragraph}`];
+  }, []);
+}
+
+export function planCreateNodesFromMarkdown(
+  plan: Plan,
+  markdown: string
+): [Plan, topNodeID: LongID] {
+  const splittedMarkdown = splitMarkdownInChunkSizes(markdown);
+  const { events, nodes } = splittedMarkdown.reduce(
+    (rdx: { events: Event[]; nodes: KnowNode[] }, md: string) => {
+      const baseID = v4();
+      const mdNodes = createNodesFromMarkdown(md, baseID, plan.user.publicKey);
+      const publishNodeEvent = finalizeEvent(
+        {
+          kind: KIND_KNOWLEDGE_NODE_COLLECTION,
+          pubkey: plan.user.publicKey,
+          created_at: newTimestamp(),
+          tags: [["d", baseID]],
+          content: md,
+        },
+        plan.user.privateKey
+      );
+      return {
+        events: [...rdx.events, publishNodeEvent],
+        nodes: [...rdx.nodes, ...mdNodes],
+      };
+    },
+    { events: [], nodes: [] }
+  );
+  const [relations, topNodeID] = createRelationsFromParagraphNodes(
     nodes,
-    topNodeID: topNode.id,
-    relations,
+    plan.user.publicKey
+  );
+  const planWithRelations = planUpsertRelations(plan, relations);
+  const userDB = planWithRelations.knowledgeDBs.get(
+    plan.user.publicKey,
+    newDB()
+  );
+  const updatedNodes = userDB.nodes.merge(
+    Map(nodes.map((node) => [shortID(node.id), node]))
+  );
+  const updatedDB = {
+    ...userDB,
+    nodes: updatedNodes,
   };
+
+  const finalPlan = {
+    ...planWithRelations,
+    knowledgeDBs: planWithRelations.knowledgeDBs.set(
+      plan.user.publicKey,
+      updatedDB
+    ),
+    publishEvents: planWithRelations.publishEvents.push(...events),
+  };
+  return [finalPlan, topNodeID];
 }
 
 type FileDropZoneProps = {
   children: React.ReactNode;
-  onDrop: (
-    nodes: KnowNode[],
-    relations: Relations[],
-    topNodes: Array<LongID>
-  ) => void;
+  onDrop: (plan: Plan, topNodes: Array<LongID>) => void;
 };
 
 type MarkdownReducer = {
-  nodes: KnowNode[];
+  plan: Plan;
   topNodeIDs: LongID[];
-  relations: Relations[];
 };
 
 /* eslint-disable react/jsx-props-no-spreading */
@@ -61,7 +135,7 @@ export function FileDropZone({
   children,
   onDrop,
 }: FileDropZoneProps): JSX.Element {
-  const { user } = useData();
+  const { createPlan } = usePlanner();
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     noClick: true,
     noKeyboard: true,
@@ -83,27 +157,21 @@ export function FileDropZone({
       );
       const mdNodes = markdowns.reduce(
         (rdx: MarkdownReducer, markdown: string) => {
-          const paragraphs = markdown.split("\n\n");
-          const { nodes, relations, topNodeID } = createSourceFromParagraphs(
-            paragraphs.map((paragraph: string) => {
-              const md = new MarkdownIt();
-              return convertToPlainText(md.render(paragraph));
-            }),
-            user.publicKey
+          const [plan, topNodeID] = planCreateNodesFromMarkdown(
+            rdx.plan,
+            markdown
           );
           return {
-            nodes: [...rdx.nodes, ...nodes],
+            plan,
             topNodeIDs: [...rdx.topNodeIDs, topNodeID],
-            relations: [...rdx.relations, relations],
           };
         },
         {
-          nodes: [],
+          plan: createPlan(),
           topNodeIDs: [],
-          relations: [],
         }
       );
-      onDrop(mdNodes.nodes, mdNodes.relations, mdNodes.topNodeIDs);
+      onDrop(mdNodes.plan, mdNodes.topNodeIDs);
     },
   });
   const className = isDragActive ? "dimmed flex-col-100" : "flex-col-100";

--- a/src/components/MarkdownUpload.test.tsx
+++ b/src/components/MarkdownUpload.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { List } from "immutable";
+import { ViewContextProvider, newRelations } from "../ViewContext";
+import { execute } from "../executor";
+import { createPlan, planUpsertRelations } from "../planner";
+import { ALICE, renderWithTestData, setup, UpdateState } from "../utils.test";
+import { planCreateNodesFromMarkdown } from "./FileDropZone";
+import { Column } from "./Column";
+import { addRelationToRelations, joinID } from "../connections";
+
+const TEST_FILE = `# Programming Languages
+
+## Java
+
+Java is a programming language
+
+## Python
+
+Python is a programming language
+`;
+
+async function uploadAndRenderMarkdown(alice: UpdateState): Promise<void> {
+  const [plan, topNodeID] = planCreateNodesFromMarkdown(
+    createPlan(alice()),
+    TEST_FILE
+  );
+  const wsID = joinID(alice().user.publicKey, "my-first-workspace");
+  const addNodeToWS = planUpsertRelations(
+    plan,
+    addRelationToRelations(
+      newRelations(wsID, "", alice().user.publicKey),
+      topNodeID
+    )
+  );
+  await execute({
+    ...alice(),
+    plan: addNodeToWS,
+  });
+
+  renderWithTestData(
+    <ViewContextProvider root={wsID} indices={List([0])}>
+      <Column />
+    </ViewContextProvider>,
+    alice()
+  );
+  await screen.findByText("Programming Languages");
+}
+
+test("Markdown Upload", async () => {
+  const [alice] = setup([ALICE]);
+  await uploadAndRenderMarkdown(alice);
+  screen.getByText("Java");
+  screen.getByText("Java is a programming language");
+  screen.getByText("Python");
+  screen.getByText("Python is a programming language");
+});
+
+test("Delete Node uploaded from Markdown", async () => {
+  const [alice] = setup([ALICE]);
+  await uploadAndRenderMarkdown(alice);
+  userEvent.click(screen.getByLabelText("edit Python"));
+  userEvent.click(screen.getByLabelText("delete node"));
+
+  expect(screen.queryByText("Python")).toBeNull();
+  screen.getByText("Java");
+
+  cleanup();
+
+  const wsID = joinID(alice().user.publicKey, "my-first-workspace");
+  // Test after rerender
+  renderWithTestData(
+    <ViewContextProvider root={wsID} indices={List([0])}>
+      <Column />
+    </ViewContextProvider>,
+    alice()
+  );
+  await screen.findByText("Java");
+  expect(screen.queryByText("Python")).toBeNull();
+});
+
+test("Edit Node uploaded from Markdown", async () => {
+  const [alice] = setup([ALICE]);
+  await uploadAndRenderMarkdown(alice);
+
+  userEvent.click(screen.getByLabelText("edit Programming Languages"));
+  userEvent.keyboard("{backspace}s OOP{enter}");
+  userEvent.click(screen.getByText("Save"));
+  await screen.findByText("Programming Languages OOP");
+  expect(screen.queryByText("Programming Languages")).toBeNull();
+});
+
+/* eslint-disable no-console */
+const originalError = console.error.bind(console.error);
+// NostrQueryProvider has side effects which will lead to
+// An update to NostrQueryProvider inside a test... errors
+beforeAll(() => {
+  // eslint-disable-next-line functional/immutable-data
+  console.error = (msg, params) => {
+    if (!msg.toString().includes("getBoundingClientRect")) {
+      originalError(msg, params);
+    }
+  };
+});
+
+afterAll(() => {
+  // eslint-disable-next-line functional/immutable-data
+  console.error = originalError;
+});
+/* eslint-enable no-console */

--- a/src/components/WorkspaceColumn.tsx
+++ b/src/components/WorkspaceColumn.tsx
@@ -13,11 +13,7 @@ import {
   useNode,
   upsertRelations,
 } from "../ViewContext";
-import {
-  planBulkUpsertNodes,
-  planBulkUpsertRelations,
-  usePlanner,
-} from "../planner";
+import { Plan, usePlanner } from "../planner";
 
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable @typescript-eslint/unbound-method */
@@ -37,23 +33,12 @@ export function WorkspaceColumnView(): JSX.Element | null {
 
 export function EmptyColumn(): JSX.Element {
   const viewContext = useViewPath();
-  const { createPlan, executePlan } = usePlanner();
-  const onDropFiles = (
-    nodes: KnowNode[],
-    relations: Relations[],
-    topNodes: Array<LongID>
-  ): void => {
-    const bulkUpsertPlan = planBulkUpsertNodes(createPlan(), nodes);
-    const addTopNodesPlan = upsertRelations(
-      bulkUpsertPlan,
-      viewContext,
-      (r: Relations) => addRelationToRelations(r, topNodes[0])
+  const { executePlan } = usePlanner();
+  const onDropFiles = (plan: Plan, topNodes: Array<LongID>): void => {
+    const addTopNodesPlan = upsertRelations(plan, viewContext, (r: Relations) =>
+      addRelationToRelations(r, topNodes[0])
     );
-    const addRelationsPlan = planBulkUpsertRelations(
-      addTopNodesPlan,
-      relations
-    );
-    executePlan(addRelationsPlan);
+    executePlan(addTopNodesPlan);
   };
   return (
     <WorkspaceColumn>

--- a/src/connections.tsx
+++ b/src/connections.tsx
@@ -171,9 +171,9 @@ export function bulkAddRelations(
   }, relations);
 }
 
-export function newNode(text: string, myself: PublicKey): KnowNode {
+export function newNode(text: string, myself: PublicKey, id?: ID): KnowNode {
   return {
     text,
-    id: joinID(myself, v4()),
+    id: joinID(myself, id || v4()),
   };
 }

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -13,6 +13,9 @@ export const KIND_RELATION_TYPES = 11076;
 
 export const KIND_KNOWLEDGE_LIST = 34750;
 export const KIND_KNOWLEDGE_NODE = 34751;
+// Essentially a markdown which is not editable
+export const KIND_KNOWLEDGE_NODE_COLLECTION = 2945;
+
 export const KIND_DELETE = 5;
 
 export const KIND_RELAY_METADATA_EVENT = 10002;

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -29,6 +29,8 @@ import { MockRelayPool, mockRelayPool } from "./nostrMock.test";
 import { DEFAULT_SETTINGS } from "./settings";
 import { NostrAuthContext } from "./NostrAuthContext";
 import { FocusContext, FocusContextProvider } from "./FocusContextProvider";
+import { TemporaryViewProvider } from "./components/TemporaryViewContext";
+import { DND } from "./dnd";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 test.skip("skip", () => {});
@@ -235,7 +237,7 @@ function getContactsOfContacts(appState: TestAppState): ContactsOfContacts {
   return parseContactOfContactsEvents(events);
 }
 
-type UpdateState = () => TestAppState;
+export type UpdateState = () => TestAppState;
 
 export function setup(
   users: KeyPair[],
@@ -271,19 +273,6 @@ export async function addContact(
     ...utils,
     plan,
   });
-  // TODO: remove if tests are not flaky
-  /*
-  const filter = {
-    kinds: [KEY_DISTR_EVENT],
-    authors: [utils.user.publicKey],
-    "#p": [publicKey],
-  };
-  await waitFor(() => {
-    expect(
-      utils.relayPool.getEvents().filter((e) => matchFilter(filter, e)).length
-    ).toBeGreaterThanOrEqual(1);
-  });
-   */
 }
 
 export async function connectContacts(
@@ -304,7 +293,14 @@ export function renderWithTestData(
   const utils = renderApis(
     <Routes>
       <Route element={<RequireLogin />}>
-        <Route path="*" element={<>{children}</>} />
+        <Route
+          path="*"
+          element={
+            <TemporaryViewProvider>
+              <DND>{children}</DND>
+            </TemporaryViewProvider>
+          }
+        />
       </Route>
     </Routes>,
     props


### PR DESCRIPTION
events, upload the full Markdown and split them
when reading in order to increase efficiency.

Test case went from 2min. loading time to 5s.