### PR TITLE
change publicPath in output to `/` to avoid loading

### DIFF
--- a/config/webpack/production.config.js
+++ b/config/webpack/production.config.js
@@ -20,7 +20,7 @@ module.exports = {
     path: path.join(__dirname, "../../build"),
     filename: "static/js/[name].[contenthash:8].js",
     chunkFilename: "static/js/[name].[contenthash:8].chunk.js",
-    publicPath: "",
+    publicPath: "/",
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
errors when opening another URL than `/`