### PR TITLE
more default relays

### DIFF
--- a/src/executor.tsx
+++ b/src/executor.tsx
@@ -4,7 +4,7 @@ import { Plan } from "./planner";
 import { FinalizeEvent } from "./Apis";
 
 // Timeout in ms for pulish() on a relay
-export const RELAY_TIMEOUT = 2000;
+export const PUBLISH_TIMEOUT = 5000;
 
 async function publishEvent(
   relayPool: SimplePool,
@@ -22,7 +22,7 @@ async function publishEvent(
     });
   const results = await Promise.allSettled(
     relayPool.publish(writeRelayUrls, event).map((promise) => {
-      return Promise.race([promise, timeout(RELAY_TIMEOUT)]);
+      return Promise.race([promise, timeout(PUBLISH_TIMEOUT)]);
     })
   );
   // If one message can be sent publish is a success,

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -16,9 +16,13 @@ export const KIND_RELAY_METADATA_EVENT = 10002;
 
 export const DEFAULT_RELAYS: Relays = [
   { url: "wss://relay.damus.io/", read: true, write: true },
-  { url: "wss://relay.snort.social/", read: true, write: true },
   { url: "wss://nos.lol/", read: true, write: true },
-  { url: "wss://nostr.wine/", read: true, write: true },
+  { url: "wss://relay.nostr.band/", read: true, write: true },
+  { url: "wss://nostr-01.bolt.observer/", read: true, write: true },
+  { url: "wss://nostr.cercatrova.me/", read: true, write: true },
+  { url: "wss://nostr.fmt.wiz.biz/", read: true, write: true },
+  { url: "wss://nostr.mom/", read: true, write: true },
+  { url: "wss://nostr.noones.com/", read: true, write: true },
 ];
 
 // eslint-disable-next-line functional/no-let


### PR DESCRIPTION
if there are too many relays in the list, it seems that subscribeMany leads to an error, for some reason we are sending on closed connections

```
index.js:716 Uncaught (in promise) Error: sending on closed connection
    at AbstractRelay.send (index.js:716:1)
    at Subscription.close (index.js:813:1)
    at AbstractRelay.closeAllSubscriptions (index.js:570:1)
    at ws.onclose (index.js:618:1)
```