### PR TITLE
publishing status per relay

### DIFF
--- a/src/DataContext.tsx
+++ b/src/DataContext.tsx
@@ -22,6 +22,7 @@ export function DataContextProvider({
   relays,
   knowledgeDBs,
   relaysInfos,
+  publishResults,
 }: DataContextProps & {
   children: React.ReactNode;
 }): JSX.Element {
@@ -34,6 +35,7 @@ export function DataContextProvider({
         relays,
         knowledgeDBs,
         relaysInfos,
+        publishResults,
       }}
     >
       {children}

--- a/src/Workspace.scss
+++ b/src/Workspace.scss
@@ -383,8 +383,8 @@ body {
   color: green;
 }
 
-.massive-icon {
-  font-size: 300px;
+.icon-large {
+  font-size: 2rem;
 }
 
 .outer-node-title .dropdown-toggle::after {

--- a/src/components/LoadingSpinnerButton.tsx
+++ b/src/components/LoadingSpinnerButton.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { Spinner } from "react-bootstrap";
+import { Button } from "./Ui";
+
+export type LoadingSpinnerBtnProps = {
+  children?: React.ReactNode;
+  onClick?: () => Promise<void>;
+  afterOnClick?: () => void;
+  className?: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+  type?: "submit" | "button";
+};
+
+export function LoadingSpinnerButton({
+  children,
+  onClick,
+  afterOnClick,
+  className,
+  disabled,
+  ariaLabel,
+  type,
+}: LoadingSpinnerBtnProps): JSX.Element {
+  const [loading, setLoading] = useState(false);
+  const submit = async (): Promise<void> => {
+    if (onClick) {
+      setLoading(true);
+      await onClick();
+      setLoading(false);
+      if (afterOnClick !== undefined) {
+        afterOnClick();
+      }
+    }
+  };
+  if (loading) {
+    return <Spinner animation="border" role="status" />;
+  }
+  return (
+    <Button
+      className={className}
+      ariaLabel={ariaLabel}
+      onClick={submit}
+      disabled={disabled}
+      type={type}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import { DeleteNode } from "./DeleteNode";
 import { NotificationCenter } from "./NotificationCenter";
 import { useData } from "../DataContext";
 import { planPublishSettings, usePlanner } from "../planner";
+import { PublishingStatus } from "./PublishingStatus";
 
 type NavBarProps = {
   logout: () => void;
@@ -64,6 +65,7 @@ export function NavBar({ logout }: NavBarProps): JSX.Element {
           </div>
         )}
         <div className="navbar-right">
+          <PublishingStatus />
           <NotificationCenter />
           <Dropdown className="options-dropdown">
             <Dropdown.Toggle

--- a/src/components/PublishingStatus.test.tsx
+++ b/src/components/PublishingStatus.test.tsx
@@ -1,13 +1,23 @@
+import React from "react";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { setup, ALICE, renderApp, typeNewNode } from "../utils.test";
+import { Event } from "nostr-tools";
+import {
+  setup,
+  ALICE,
+  renderApp,
+  typeNewNode,
+  renderWithTestData,
+} from "../utils.test";
+import { PublishingStatus } from "./PublishingStatus";
+import { WorkspaceView } from "./Workspace";
+import { MockRelayPool, mockRelayPool } from "../nostrMock.test";
 
 test("Publishing Status is shown per relay", async () => {
   const [alice] = setup([ALICE]);
   const view = renderApp(alice());
   await typeNewNode(view, "New Note");
-  const publishingStatusBtn = screen.getByLabelText("publishing status");
-  userEvent.click(publishingStatusBtn);
+  userEvent.click(screen.getByLabelText("publishing status"));
   await screen.findByText("Publishing Status");
   screen.getByText("Relay wss://relay.damus.io/:");
   expect(
@@ -15,4 +25,65 @@ test("Publishing Status is shown per relay", async () => {
       "100% of the last 3 events could be published on this relay"
     )
   ).toHaveLength(4);
+});
+
+test("Publishing Status is shown as failed", async () => {
+  const [alice] = setup([ALICE]);
+  const utils = alice();
+  const view = renderWithTestData(
+    <>
+      <PublishingStatus />
+      <WorkspaceView />
+    </>,
+    {
+      ...utils,
+      relayPool: {
+        ...mockRelayPool(),
+        publish: (relays: Array<string>, event: Event): Promise<string>[] => {
+          if (event.kind === 34751) {
+            return [
+              Promise.reject(new Error("too many requests")),
+              Promise.reject(new Error("paid relay")),
+              Promise.resolve("fulfilled"),
+              Promise.reject(new Error("paid relay")),
+            ];
+          }
+          return [
+            Promise.resolve("fulfilled"),
+            Promise.reject(new Error("paid relay")),
+            Promise.resolve("fulfilled"),
+            Promise.reject(new Error("paid relay")),
+          ];
+        },
+      } as unknown as MockRelayPool,
+    }
+  );
+  await typeNewNode(view, "Hello World");
+
+  userEvent.click(screen.getByLabelText("publishing status"));
+  await screen.findByText("Publishing Status");
+  screen.getByText("Relay wss://relay.damus.io/:");
+  screen.getByText("67% of the last 3 events could be published on this relay");
+  screen.getByText(
+    "The last event could not be published because: Error: too many requests"
+  );
+  screen.getByText("Relay wss://relay.snort.social/:");
+  screen.getByText("Relay wss://nostr.wine/:");
+  expect(
+    screen.getAllByText(
+      "0% of the last 3 events could be published on this relay"
+    )
+  ).toHaveLength(2);
+  expect(
+    screen.getAllByText(
+      "The last event could not be published because: Error: paid relay"
+    )
+  ).toHaveLength(2);
+  screen.getByText("Relay wss://nos.lol/:");
+  screen.getByText(
+    "100% of the last 3 events could be published on this relay"
+  );
+  screen.getByText(
+    "The last event could not be published because: Error: too many requests"
+  );
 });

--- a/src/components/PublishingStatus.test.tsx
+++ b/src/components/PublishingStatus.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setup, ALICE, renderApp, typeNewNode } from "../utils.test";
+
+test("Publishing Status is shown per relay", async () => {
+  const [alice] = setup([ALICE]);
+  const view = renderApp(alice());
+  await typeNewNode(view, "New Note");
+  const publishingStatusBtn = screen.getByLabelText("publishing status");
+  userEvent.click(publishingStatusBtn);
+  await screen.findByText("Publishing Status");
+  screen.getByText("Relay wss://relay.damus.io/:");
+  expect(
+    screen.getAllByText(
+      "100% of the last 3 events could be published on this relay"
+    )
+  ).toHaveLength(4);
+});

--- a/src/components/PublishingStatus.tsx
+++ b/src/components/PublishingStatus.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Dropdown } from "react-bootstrap";
+import { useData } from "../DataContext";
+
+function getStatusCount(status: Array<PublishStatus>, type: string): number {
+  return status.filter((s) => s.status === type).length;
+}
+function getLastRejectedReason(
+  status: Array<PublishStatus>
+): string | undefined {
+  const lastRejected = status
+    .slice()
+    .reverse()
+    .find((s) => s.status === "rejected");
+  return lastRejected ? lastRejected.reason : undefined;
+}
+
+function RelayPublishStatus({
+  status,
+  relayUrl,
+}: {
+  status: Array<PublishStatus>;
+  relayUrl: string;
+}): JSX.Element {
+  const navigate = useNavigate();
+  const numberFulfilled = getStatusCount(status, "fulfilled");
+  const numberRejected = getStatusCount(status, "rejected");
+  const totalNumber = numberFulfilled + numberRejected;
+  const percentage = Math.round((numberFulfilled / totalNumber) * 100);
+  const isWarning = percentage < 50;
+  const lastRejectedReason = getLastRejectedReason(status);
+  return (
+    <>
+      <Dropdown.Divider />
+      <Dropdown.Item tabIndex={0} onClick={() => navigate("/relays")}>
+        <div className="flex-row-space-between">
+          <div className="me-2">
+            <div className="bold">{`Relay ${relayUrl}:`}</div>
+            <div className="mt-1">
+              {totalNumber > 0
+                ? `${
+                    totalNumber === 1
+                      ? `The last event ${
+                          numberFulfilled === 1 ? "could" : "could not"
+                        }`
+                      : `${percentage}% of the last ${totalNumber} events could`
+                  } be published on this relay`
+                : `No events were attempted to be published on this relay`}
+            </div>
+            {lastRejectedReason && (
+              <div>
+                {`The last event could not be published because: ${lastRejectedReason}`}
+              </div>
+            )}
+          </div>
+          <div className="ms-2 flex-row-center align-center icon-large">
+            <div
+              className={
+                isWarning
+                  ? "simple-icon-exclamation danger"
+                  : "simple-icon-check success"
+              }
+            />
+          </div>
+        </div>
+      </Dropdown.Item>
+    </>
+  );
+}
+
+export function PublishingStatus(): JSX.Element | null {
+  const { publishResults } = useData();
+  if (publishResults.size === 0) {
+    return null;
+  }
+
+  return (
+    <Dropdown>
+      <Dropdown.Toggle
+        as="button"
+        id="publishing-status-dropdown"
+        key="publishing-status-dropdown"
+        className="btn"
+        style={{ paddingTop: "6px", paddingBottom: "4px" }}
+        aria-label="publishing status"
+        tabIndex={0}
+      >
+        <span className="simple-icon-info" />
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        <Dropdown.Item key="publishing-status-header" disabled>
+          <div className="bold">
+            <h3>Publishing Status</h3>
+          </div>
+        </Dropdown.Item>
+        {publishResults
+          .map((status, relayUrl) => {
+            return (
+              <RelayPublishStatus
+                status={status}
+                relayUrl={relayUrl}
+                // eslint-disable-next-line react/no-array-index-key
+                key={`publishing-status ${relayUrl}`}
+              />
+            );
+          })
+          .valueSeq()}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}

--- a/src/nostrMock.test.tsx
+++ b/src/nostrMock.test.tsx
@@ -38,12 +38,13 @@ async function broadcastEvent(
 async function broadcastEvents(
   subs: Map<string, Subscription>,
   events: Array<Event>
-): Promise<void> {
+): Promise<string> {
   await Promise.all(
     events.map(async (event) => {
       await broadcastEvent(subs, event);
     })
   );
+  return "";
 }
 
 export function mockRelayPool(): MockRelayPool {
@@ -76,10 +77,10 @@ export function mockRelayPool(): MockRelayPool {
         close: () => subs.remove(id),
       };
     },
-    publish: (relays: string[], event: Event): Promise<void>[] => {
+    publish: (relays: string[], event: Event): Promise<string>[] => {
       // eslint-disable-next-line functional/immutable-data
       events.push(event);
-      return [broadcastEvents(subs, [event])];
+      return relays.map(() => broadcastEvents(subs, [event]));
     },
     getEvents: () => events,
   } as unknown as MockRelayPool;

--- a/src/planner.tsx
+++ b/src/planner.tsx
@@ -36,21 +36,24 @@ export type Plan = Data & {
 export function PlanningContextProvider({
   children,
   addNewEvents,
+  updatePublishResults,
 }: {
   children: React.ReactNode;
   addNewEvents: (events: List<UnsignedEvent>) => void;
+  updatePublishResults: (results: Array<PublishResultsOfEvent>) => void;
 }): JSX.Element {
   const { relayPool, finalizeEvent } = useApis();
 
   const executePlan = async (plan: Plan): Promise<void> => {
     // TODO: this needs a lot of error handling etc...
     addNewEvents(plan.publishEvents);
-    return execute({
+    const results = await execute({
       plan,
       relayPool,
       relays: plan.relays.filter((r) => r.write === true),
       finalizeEvent,
     });
+    updatePublishResults(results);
   };
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,13 @@ declare global {
 
   type Relays = Array<Relay>;
 
+  type PublishStatus = {
+    status: "rejected" | "fulfilled";
+    reason?: string;
+  };
+  type PublishResultsOfEvent = Map<string, PublishStatus>;
+  type PublishResults = Map<string, Array<PublishStatus>>;
+
   type KnowledgeDBs = Map<PublicKey, KnowledgeData>;
 
   type Data = {
@@ -41,6 +48,7 @@ declare global {
     relays: Relays;
     knowledgeDBs: KnowledgeDBs;
     relaysInfos: Map<string, RelayInformation | undefined>;
+    publishResults: PublishResults;
   };
 
   type LocalStorage = {

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -155,10 +155,10 @@ type TestApis = Omit<Apis, "fileStore" | "relayPool"> & {
 
 function applyApis(props?: Partial<TestApis>): TestApis {
   return {
-    fileStore: mockFileStore(),
-    relayPool: mockRelayPool(),
-    finalizeEvent: mockFinalizeEvent(),
-    nip11: {
+    fileStore: props?.fileStore || mockFileStore(),
+    relayPool: props?.relayPool || mockRelayPool(),
+    finalizeEvent: props?.finalizeEvent || mockFinalizeEvent(),
+    nip11: props?.nip11 || {
       searchDebounce: 0,
       fetchRelayInformation: jest.fn().mockReturnValue(
         Promise.resolve({

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -264,6 +264,7 @@ const DEFAULT_DATA_CONTEXT_PROPS: DataContextProps = {
   relays: DEFAULT_RELAYS,
   knowledgeDBs: Map<PublicKey, KnowledgeData>(),
   relaysInfos: Map<string, RelayInformation | undefined>(),
+  publishResults: Map<string, Array<PublishStatus>>(),
 };
 
 type TestAppState = DataContextProps & TestApis;


### PR DESCRIPTION
at the moment i can show the publishing status per relay of the last event or events, shall i do a history of events too? resp.  i'd have to bring a Map with<sentEvents, Status> back to Data for that. does that make sense?

I imagined to display something like "x % of the last 100 Events" could be sent to this relay" but is this useful?