### PR TITLE
fix show loading node if view changes

### DIFF
--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -25,6 +25,7 @@ import {
   useQueryKnowledgeData,
 } from "../dataQuery";
 import { RegisterQuery } from "../LoadingStatus";
+import { shortID } from "../connections";
 
 const LOAD_EXTRA = 10;
 
@@ -61,7 +62,7 @@ export function TreeViewNodeLoader({
   return (
     <MergeKnowledgeDB knowledgeDBs={mergedDBs}>
       <RegisterQuery
-        nodesBeeingQueried={nodeIDs.toArray()}
+        nodesBeeingQueried={nodeIDs.map((longID) => shortID(longID)).toArray()}
         allEventsProcessed={allEventsProcessed}
       >
         {children}


### PR DESCRIPTION
the bug was because of the nodesBeingQueried having stored the longId when resitering the queries for the treeview