### PR TITLE
[draft][codex] Explore node kind filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 - node v16.14.2
 
+## Semantic Markers
+
+The proposed compact relation/review marker grammar is documented in
+[docs/semantic-markers.md](docs/semantic-markers.md).
+
 # Build cli
 
   npx esbuild src/cli/index.ts \

--- a/docs/semantic-markers.md
+++ b/docs/semantic-markers.md
@@ -79,3 +79,40 @@ Examples:
 - (-?) This passage contradicts the statement.
 ```
 
+## Typed Contains Orders
+
+`contains` is the default structural edge. It can be interpreted by node type,
+so the same stable node can appear in multiple curated orders without being
+duplicated.
+
+- `topic contains topic`: logical outline
+- `topic contains statement`: thematic placement
+- `statement contains statement`: nested argument or excerpt structure
+- `source contains statement`: provenance; the statement comes from the source
+- `person contains source`: works by a person, usually chronological
+- `person contains task`: operational work related to a person
+
+This lets a statement-first view stay focused on the logical topic tree:
+
+```markdown
+# Praxeology
+
+- (!) Human action is purposeful behavior. <!-- ref:statement-action-purposeful -->
+```
+
+The source view can contain the same statement ID:
+
+```markdown
+# Human Action
+
+- Human action is purposeful behavior. <!-- ref:statement-action-purposeful -->
+```
+
+The UI can then answer "which source and person does this statement come from?"
+with a reverse `contains` index:
+
+1. Find `source` parents that contain the statement ID.
+2. Find `person` parents that contain those source IDs.
+3. Show source/person in a side panel or lazy expansion without forcing every
+   topic view to inline provenance details.
+

--- a/docs/semantic-markers.md
+++ b/docs/semantic-markers.md
@@ -1,0 +1,81 @@
+# Semantic Markers
+
+Status: draft for review
+
+This document proposes a compact marker grammar for knowstr-compatible semantic
+graphs. The goal is to keep relationship semantics small while making draft
+agent suggestions visible in Markdown.
+
+## Node Types
+
+Visible graph nodes should use a small set of types:
+
+- `topic`
+- `statement`
+- `source`
+- `person`
+- `task`
+
+`author` is not a separate node type. An author is a role of a `person`, and
+authorship is represented from a `source` through metadata or a relation to that
+person.
+
+## Relation Types
+
+Visible relation types should stay limited to:
+
+- `contains`
+- `relevant-for`
+- `supports`
+- `contradicts`
+- `same-as`
+
+`refines` is intentionally not a separate relation. Refinement, contextual
+closeness, overlap, and "important for this question" are covered by
+`relevant-for`.
+
+`maybe-relevant` is also not a relation. Maybe/draft is a review status.
+
+## Marker Grammar
+
+The base symbol describes the relation or evaluation. A trailing `?` marks the
+relation as draft/proposed.
+
+| Marker | Meaning |
+|---|---|
+| no marker | accepted `contains` |
+| `(?)` | draft `contains` |
+| `(!)` | accepted `relevant-for` |
+| `(!?)` | draft `relevant-for` |
+| `(~)` | accepted weak `relevant-for` |
+| `(~?)` | draft weak `relevant-for` |
+| `(+)` | accepted `supports` |
+| `(+?)` | draft `supports` |
+| `(-)` | accepted `contradicts` |
+| `(-?)` | draft `contradicts` |
+| `(=)` | accepted `same-as` |
+| `(=?)` | draft `same-as` |
+| `(x)` | rejected |
+| `(x?)` | rejection proposed |
+
+The rule is: base symbol = semantic relation/evaluation; trailing `?` = draft
+status.
+
+## Same-As
+
+`same-as` is strict. It means two nodes should be treated as the same entity or
+merged. It is appropriate for real duplicates, spelling variants, language
+variants, or confirmed synonyms.
+
+Similar, overlapping, or contextually related topics should use `relevant-for`,
+not `same-as`.
+
+Examples:
+
+```markdown
+- (=?) Volkswirtschaftslehre
+- (!?) Bitcoin
+- (+?) This passage supports the statement.
+- (-?) This passage contradicts the statement.
+```
+

--- a/src/Workspace.scss
+++ b/src/Workspace.scss
@@ -1783,6 +1783,22 @@ body:not(.keyboard-input-mode) .hover-light-bg:hover {
   }
 }
 
+.node-kind-filter-symbol {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+
+  svg {
+    fill: none;
+    height: 15px;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.7;
+    width: 15px;
+  }
+}
+
 .filter-symbol {
   font-size: 12px;
   font-weight: bold;

--- a/src/components/Draggable.tsx
+++ b/src/components/Draggable.tsx
@@ -44,6 +44,7 @@ type DraggableProps = {
   rowViewKey?: string;
   rowIndex?: number;
   rowDepth?: number;
+  displayDepth?: number;
   isActiveRow?: boolean;
   isSelected?: boolean;
   onRowFocus?: (key: string, index: number, mode: KeyboardMode) => void;
@@ -58,6 +59,7 @@ const Draggable = React.forwardRef<HTMLDivElement, DraggableProps>(
       rowViewKey = "",
       rowIndex = 0,
       rowDepth = 0,
+      displayDepth,
       isActiveRow = false,
       isSelected = false,
       onRowFocus = () => {},
@@ -148,7 +150,7 @@ const Draggable = React.forwardRef<HTMLDivElement, DraggableProps>(
         onClick={handleClick}
         onKeyDown={() => {}}
       >
-        <Node className={className} />
+        <Node className={className} displayDepth={displayDepth} />
       </div>
     );
   }
@@ -159,6 +161,7 @@ function DraggableSuggestion({
   rowViewKey,
   rowIndex,
   rowDepth,
+  displayDepth,
   isActiveRow,
   isSelected = false,
   onRowFocus,
@@ -168,6 +171,7 @@ function DraggableSuggestion({
   rowViewKey: string;
   rowIndex: number;
   rowDepth: number;
+  displayDepth?: number;
   isActiveRow: boolean;
   isSelected?: boolean;
   onRowFocus: (key: string, index: number, mode: KeyboardMode) => void;
@@ -248,7 +252,7 @@ function DraggableSuggestion({
       onClick={handleClick}
       onKeyDown={() => {}}
     >
-      <Node className={className} isSuggestion />
+      <Node className={className} isSuggestion displayDepth={displayDepth} />
     </div>
   );
 }
@@ -262,9 +266,11 @@ export function ListItem({
   onRowFocus,
   onRowClick,
   isFirstVirtual,
+  rowDepth,
 }: {
   index: number;
   treeViewPath: ViewPath;
+  rowDepth?: number;
   nextDepth?: number;
   nextViewPathStr?: string;
   activeRowKey: string;
@@ -285,7 +291,7 @@ export function ListItem({
   const isInSearchView = useIsInSearchView();
   const isViewingOtherUserContent = useIsViewingOtherUserContent();
   const selected = useIsSelected();
-  const rowDepth = viewPath.length - 1;
+  const effectiveRowDepth = rowDepth ?? viewPath.length - 1;
   const isActiveRow = activeRowKey === viewKey;
   const isEmptyNode = isEmptySemanticID(rowID);
 
@@ -309,7 +315,8 @@ export function ListItem({
         <DraggableSuggestion
           rowViewKey={viewKey}
           rowIndex={index}
-          rowDepth={rowDepth}
+          rowDepth={effectiveRowDepth}
+          displayDepth={effectiveRowDepth}
           isActiveRow={isActiveRow}
           isSelected={selected}
           onRowFocus={onRowFocus}
@@ -335,7 +342,8 @@ export function ListItem({
         copyDrag={isCopyDrag}
         rowViewKey={viewKey}
         rowIndex={index}
-        rowDepth={rowDepth}
+        rowDepth={effectiveRowDepth}
+        displayDepth={effectiveRowDepth}
         isActiveRow={isActiveRow}
         isSelected={selected}
         onRowFocus={onRowFocus}

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -95,7 +95,8 @@ function useNodeHasChildren(): boolean {
     stack,
     pane.rootNodeId,
     pane.author,
-    pane.typeFilters
+    pane.typeFilters,
+    pane.nodeKindFilters
   );
   return result.paths.size > 0;
 }
@@ -699,13 +700,15 @@ export function Node({
   className,
   cardBodyClassName,
   isSuggestion,
+  displayDepth,
 }: {
   className?: string;
   cardBodyClassName?: string;
   isSuggestion?: boolean;
+  displayDepth?: number;
 }): JSX.Element | null {
   const viewPath = useViewPath();
-  const levels = getLevels(viewPath);
+  const levels = displayDepth ?? getLevels(viewPath);
   const searchDepth = useSearchDepth();
   const { cardStyle, textStyle, textClassName, relevance } = useItemStyle();
   const cls =

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -72,13 +72,15 @@ export function PaneTreeResultProvider({
       List<ViewPath>(),
       pane.rootNodeId,
       pane.author,
-      pane.typeFilters
+      pane.typeFilters,
+      pane.nodeKindFilters
     );
   }, [
     data,
     isRootExpanded,
     pane.author,
     pane.rootNodeId,
+    pane.nodeKindFilters,
     pane.typeFilters,
     stack,
     viewPath,
@@ -104,6 +106,7 @@ function VirtuosoForColumn({
   onRowClick,
   scrollToId,
   firstVirtualKeys,
+  displayDepths,
 }: {
   nodes: List<ViewPath>;
   startIndexFromStorage: number;
@@ -117,6 +120,7 @@ function VirtuosoForColumn({
   onRowClick?: (e: React.MouseEvent, viewKey: string) => void;
   scrollToId?: string;
   firstVirtualKeys: ImmutableSet<string>;
+  displayDepths: Map<string, number>;
 }): JSX.Element {
   const data = useData();
   const location = useLocation();
@@ -207,12 +211,18 @@ function VirtuosoForColumn({
             index < nodes.size - 1 ? nodes.get(index + 1) : undefined;
           const pathKey = viewPathToString(path);
           const isFirstVirtual = firstVirtualKeys.has(pathKey);
+          const displayDepth = displayDepths.get(pathKey) ?? path.length - 1;
+          const nextDepth = nextPath
+            ? displayDepths.get(viewPathToString(nextPath)) ??
+              nextPath.length - 1
+            : undefined;
           return (
             <ViewContext.Provider value={path} key={pathKey}>
               <ListItem
                 index={index}
                 treeViewPath={viewPath}
-                nextDepth={nextPath ? nextPath.length - 1 : undefined}
+                rowDepth={displayDepth}
+                nextDepth={nextDepth}
                 nextViewPathStr={
                   nextPath ? viewPathToString(nextPath) : undefined
                 }
@@ -416,6 +426,7 @@ function Tree(): JSX.Element | null {
           onRowClick={onRowClick}
           scrollToId={pane.scrollToId}
           firstVirtualKeys={firstVirtualKeys}
+          displayDepths={treeResult?.displayDepths || Map<string, number>()}
         />
       </div>
     </VirtualRowsProvider>

--- a/src/components/TypeFilterButton.test.tsx
+++ b/src/components/TypeFilterButton.test.tsx
@@ -71,12 +71,54 @@ My Notes
     await type("My Notes{Enter}{Tab}Parent{Enter}{Tab}Child{Escape}");
 
     // Inline filter dots should exist
+    expect(
+      screen.getByLabelText("toggle Themen node kind filter")
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText("toggle Notizen node kind filter")
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText("toggle Autoren node kind filter")
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText("toggle Quellen node kind filter")
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText("toggle Tasks node kind filter")
+    ).toBeDefined();
     expect(screen.getByLabelText("toggle Relevant filter")).toBeDefined();
     expect(screen.getByLabelText("toggle Maybe Relevant filter")).toBeDefined();
     expect(
       screen.getByLabelText("toggle Little Relevant filter")
     ).toBeDefined();
     expect(screen.getByLabelText("toggle Not Relevant filter")).toBeDefined();
+  });
+
+  test("node kind filter buttons are additive", async () => {
+    const [alice] = setup([ALICE]);
+    renderTree(alice);
+
+    await type("My Notes{Enter}{Tab}Parent{Enter}{Tab}Child{Escape}");
+
+    const topics = screen.getByLabelText("toggle Themen node kind filter");
+    const notes = screen.getByLabelText("toggle Notizen node kind filter");
+    const authors = screen.getByLabelText("toggle Autoren node kind filter");
+
+    expect(topics.getAttribute("aria-pressed")).toBe("true");
+    expect(notes.getAttribute("aria-pressed")).toBe("true");
+    expect(authors.getAttribute("aria-pressed")).toBe("true");
+
+    await userEvent.click(notes);
+
+    expect(topics.getAttribute("aria-pressed")).toBe("true");
+    expect(notes.getAttribute("aria-pressed")).toBe("false");
+    expect(authors.getAttribute("aria-pressed")).toBe("true");
+
+    await userEvent.click(authors);
+
+    expect(topics.getAttribute("aria-pressed")).toBe("true");
+    expect(notes.getAttribute("aria-pressed")).toBe("false");
+    expect(authors.getAttribute("aria-pressed")).toBe("false");
   });
 
   test("toggling filter hides/shows children", async () => {

--- a/src/components/TypeFilterButton.tsx
+++ b/src/components/TypeFilterButton.tsx
@@ -4,7 +4,11 @@ import { Dropdown } from "react-bootstrap";
 import { planUpdatePanes, usePlanner } from "../planner";
 import { useData } from "../DataContext";
 import { useCurrentPane } from "../SplitPanesContext";
-import { DEFAULT_TYPE_FILTERS, TYPE_COLORS } from "../constants";
+import {
+  ALL_NODE_KIND_FILTERS,
+  DEFAULT_TYPE_FILTERS,
+  TYPE_COLORS,
+} from "../constants";
 import { IS_SMALL_SCREEN } from "./responsive";
 
 const RELEVANCE_FILTERS: {
@@ -66,6 +70,17 @@ const INCOMING_FILTER = {
   symbol: "R",
 };
 
+const NODE_KIND_FILTERS: {
+  id: NodeKind;
+  label: string;
+}[] = [
+  { id: "topic", label: "Themen" },
+  { id: "author", label: "Autoren" },
+  { id: "source", label: "Quellen" },
+  { id: "statement", label: "Notizen" },
+  { id: "task", label: "Tasks" },
+];
+
 export type FilterId =
   | Relevance
   | "suggestions"
@@ -85,6 +100,40 @@ export function useToggleFilter(): (id: FilterId) => void {
       ? currentFilters.filter((f) => f !== id)
       : [...currentFilters, id];
     const updatedPane = { ...pane, typeFilters: newFilters };
+    const newPanes = panes.map((p) => (p.id === pane.id ? updatedPane : p));
+    const plan = createPlan();
+    executePlan(planUpdatePanes(plan, newPanes));
+  };
+}
+
+function selectedNodeKindFilters(pane: Pane): NodeKind[] {
+  return pane.nodeKindFilters ?? ALL_NODE_KIND_FILTERS;
+}
+
+function isDefaultNodeKindFilter(filters: NodeKind[]): boolean {
+  return (
+    filters.length === ALL_NODE_KIND_FILTERS.length &&
+    ALL_NODE_KIND_FILTERS.every((kind) => filters.includes(kind))
+  );
+}
+
+export function useToggleNodeKindFilter(): (kind: NodeKind) => void {
+  const pane = useCurrentPane();
+  const { panes } = useData();
+  const { createPlan, executePlan } = usePlanner();
+
+  return (kind: NodeKind): void => {
+    const currentFilters = selectedNodeKindFilters(pane);
+    const isActive = currentFilters.includes(kind);
+    const nextFilters = isActive
+      ? currentFilters.filter((filter) => filter !== kind)
+      : [...currentFilters, kind];
+    const updatedPane = {
+      ...pane,
+      nodeKindFilters: isDefaultNodeKindFilter(nextFilters)
+        ? undefined
+        : nextFilters,
+    };
     const newPanes = panes.map((p) => (p.id === pane.id ? updatedPane : p));
     const plan = createPlan();
     executePlan(planUpdatePanes(plan, newPanes));
@@ -121,6 +170,77 @@ function ClickableFilterSymbol({
   );
 }
 
+function NodeKindIcon({ kind }: { kind: NodeKind }): JSX.Element {
+  if (kind === "topic") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M2.5 2.5h5L13.5 8l-5.5 5.5-5.5-5.5z" />
+        <circle cx="6" cy="6" r="1.2" />
+      </svg>
+    );
+  }
+  if (kind === "author") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <circle cx="8" cy="5" r="2.4" />
+        <path d="M3.5 13c.7-2.5 2.2-3.8 4.5-3.8s3.8 1.3 4.5 3.8" />
+      </svg>
+    );
+  }
+  if (kind === "source") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M3 3.2h3.3c1 0 1.7.4 1.7 1.2V13c0-.8-.7-1.2-1.7-1.2H3z" />
+        <path d="M13 3.2H9.7c-1 0-1.7.4-1.7 1.2V13c0-.8.7-1.2 1.7-1.2H13z" />
+      </svg>
+    );
+  }
+  if (kind === "task") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <rect x="3" y="3" width="10" height="10" rx="1.5" />
+        <path d="M5.4 8.2 7.2 10l3.6-4" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4 2.5h6l2 2V13.5H4z" />
+      <path d="M10 2.5V5h2" />
+      <path d="M6 8h4" />
+      <path d="M6 10.5h4" />
+    </svg>
+  );
+}
+
+function NodeKindFilterButton({
+  id,
+  label,
+  isActive,
+  onClick,
+}: {
+  id: NodeKind;
+  label: string;
+  isActive: boolean;
+  onClick: (id: NodeKind) => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="clickable-filter-symbol node-kind-filter-symbol"
+      style={{
+        color: isActive ? TYPE_COLORS.referenced_by : TYPE_COLORS.inactive,
+      }}
+      onClick={() => onClick(id)}
+      aria-label={`toggle ${label} node kind filter`}
+      aria-pressed={isActive}
+      title={label}
+    >
+      <NodeKindIcon kind={id} />
+    </button>
+  );
+}
+
 const ALL_FILTERS = [
   ...RELEVANCE_FILTERS,
   SUGGESTIONS_FILTER,
@@ -131,11 +251,17 @@ const ALL_FILTERS = [
 function FilterPopover({
   currentFilters,
   onToggle,
+  currentNodeKindFilters,
+  onNodeKindToggle,
 }: {
   currentFilters: FilterId[];
   onToggle: (id: FilterId) => void;
+  currentNodeKindFilters: NodeKind[];
+  onNodeKindToggle: (id: NodeKind) => void;
 }): JSX.Element {
   const isFilterActive = (id: FilterId): boolean => currentFilters.includes(id);
+  const isNodeKindActive = (id: NodeKind): boolean =>
+    currentNodeKindFilters.includes(id);
   return (
     <Dropdown className="filter-popover">
       <Dropdown.Toggle
@@ -146,6 +272,17 @@ function FilterPopover({
         ∇
       </Dropdown.Toggle>
       <Dropdown.Menu>
+        <div className="filter-popover-symbols">
+          {NODE_KIND_FILTERS.map((filter) => (
+            <NodeKindFilterButton
+              key={filter.id}
+              id={filter.id}
+              label={filter.label}
+              isActive={isNodeKindActive(filter.id)}
+              onClick={onNodeKindToggle}
+            />
+          ))}
+        </div>
         <div className="filter-popover-symbols">
           {ALL_FILTERS.map((f) => (
             <ClickableFilterSymbol
@@ -168,20 +305,37 @@ export function InlineFilterDots(): JSX.Element {
   const isSmallScreen = useMediaQuery(IS_SMALL_SCREEN);
   const pane = useCurrentPane();
   const currentFilters = pane.typeFilters || DEFAULT_TYPE_FILTERS;
+  const currentNodeKindFilters = selectedNodeKindFilters(pane);
   const isFilterActive = (id: FilterId): boolean => currentFilters.includes(id);
+  const isNodeKindActive = (id: NodeKind): boolean =>
+    currentNodeKindFilters.includes(id);
   const handleFilterToggle = useToggleFilter();
+  const handleNodeKindToggle = useToggleNodeKindFilter();
 
   if (isSmallScreen) {
     return (
       <FilterPopover
         currentFilters={currentFilters}
         onToggle={handleFilterToggle}
+        currentNodeKindFilters={currentNodeKindFilters}
+        onNodeKindToggle={handleNodeKindToggle}
       />
     );
   }
 
   return (
     <div className="inline-filter-symbols">
+      <span className="filter-group">
+        {NODE_KIND_FILTERS.map((filter) => (
+          <NodeKindFilterButton
+            key={filter.id}
+            id={filter.id}
+            label={filter.label}
+            isActive={isNodeKindActive(filter.id)}
+            onClick={handleNodeKindToggle}
+          />
+        ))}
+      </span>
       <span className="filter-group">
         {RELEVANCE_FILTERS.map((f) => (
           <ClickableFilterSymbol

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,14 @@ export const DEFAULT_TYPE_FILTERS: (
   "incoming",
 ];
 
+export const ALL_NODE_KIND_FILTERS: NodeKind[] = [
+  "topic",
+  "author",
+  "source",
+  "statement",
+  "task",
+];
+
 export const suggestionSettings = { maxSuggestions: 5 };
 
 // Solarized accent colors for relevance and argument types

--- a/src/dnd.tsx
+++ b/src/dnd.tsx
@@ -156,7 +156,8 @@ export function getDropDestinationFromTreeView(
     List<ViewPath>(),
     rootNode,
     pane.author,
-    pane.typeFilters
+    pane.typeFilters,
+    pane.nodeKindFilters
   );
   const adjustedIndex = destinationIndex - 1;
   const dropBefore = nodes.get(adjustedIndex);

--- a/src/documentFormat.ts
+++ b/src/documentFormat.ts
@@ -4,7 +4,8 @@ export function formatRootHeading(
   basedOn?: LongID,
   snapshotDTag?: string,
   anchor?: RootAnchor,
-  systemRole?: RootSystemRole
+  systemRole?: RootSystemRole,
+  nodeKind?: NodeKind
 ): string {
   const parts = [
     `id:${rootUuid}`,
@@ -27,6 +28,7 @@ export function formatRootHeading(
       ? [`sourceParent="${anchor.sourceParentNodeID}"`]
       : []),
     ...(systemRole ? [`systemRole="${systemRole}"`] : []),
+    ...(nodeKind ? [`nodeKind="${nodeKind}"`] : []),
   ];
   return `# ${rootText} <!-- ${parts.join(" ")} -->`;
 }
@@ -37,6 +39,7 @@ export function formatNodeAttrs(
     hidden?: boolean;
     basedOn?: LongID;
     userPublicKey?: PublicKey;
+    nodeKind?: NodeKind;
   }
 ): string {
   const parts: string[] = [
@@ -46,6 +49,7 @@ export function formatNodeAttrs(
       : []),
     ...(options?.hidden ? ["hidden"] : []),
     ...(options?.basedOn ? [`basedOn="${options.basedOn}"`] : []),
+    ...(options?.nodeKind ? [`nodeKind="${options.nodeKind}"`] : []),
   ];
   if (parts.length === 0) {
     return "";

--- a/src/documentRenderer.ts
+++ b/src/documentRenderer.ts
@@ -87,6 +87,7 @@ function serializeNodeItems(
         ...(resolvedChild.userPublicKey
           ? { userPublicKey: resolvedChild.userPublicKey }
           : {}),
+        ...(resolvedChild.nodeKind ? { nodeKind: resolvedChild.nodeKind } : {}),
       });
 
       if (resolvedChild.blockKind === "heading") {
@@ -209,7 +210,8 @@ export function renderDocumentMarkdown(
     rootNode.basedOn,
     options?.snapshotDTag ?? rootNode.snapshotDTag,
     rootNode.anchor ?? createRootAnchor(getNodeContext(knowledgeDBs, rootNode)),
-    rootNode.systemRole
+    rootNode.systemRole,
+    rootNode.nodeKind
   );
   return formatWithFrontMatter(
     `${addBlankLinesAroundHeadings([rootLine, ...serialized.lines]).join(

--- a/src/markdownNodes.ts
+++ b/src/markdownNodes.ts
@@ -63,6 +63,7 @@ function materializeTreeNode(
       listOrdered: treeNode.listOrdered,
     }),
     ...(treeNode.listStart !== undefined && { listStart: treeNode.listStart }),
+    ...(treeNode.nodeKind !== undefined && { nodeKind: treeNode.nodeKind }),
   };
 
   const childSemanticContext = semanticContext.push(

--- a/src/markdownTree.ts
+++ b/src/markdownTree.ts
@@ -26,6 +26,19 @@ const ARGUMENT_CHARS: Record<string, Argument> = {
 
 const PREFIX_RE = /^(\([!?~x+-]{1,2}\)\s*)+/;
 
+function parseNodeKind(value: string | undefined): NodeKind | undefined {
+  if (
+    value === "topic" ||
+    value === "author" ||
+    value === "source" ||
+    value === "statement" ||
+    value === "task"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
 type ParsedComment = {
   uuid: string;
   hidden: boolean;
@@ -34,6 +47,7 @@ type ParsedComment = {
   anchor: RootAnchor | undefined;
   systemRole: RootSystemRole | undefined;
   userPublicKey: PublicKey | undefined;
+  nodeKind: NodeKind | undefined;
 };
 
 function parseIdComment(content: string): ParsedComment | undefined {
@@ -66,6 +80,7 @@ function parseIdComment(content: string): ParsedComment | undefined {
   const userPublicKey = (attrsMap.userPublicKey || undefined) as
     | PublicKey
     | undefined;
+  const nodeKind = parseNodeKind(attrsMap.nodeKind);
 
   const anchor =
     anchorContext ||
@@ -100,6 +115,7 @@ function parseIdComment(content: string): ParsedComment | undefined {
     anchor,
     systemRole,
     userPublicKey,
+    nodeKind,
   };
 }
 
@@ -260,6 +276,7 @@ export type MarkdownTreeNode = {
   anchor?: RootAnchor;
   systemRole?: RootSystemRole;
   userPublicKey?: PublicKey;
+  nodeKind?: NodeKind;
 };
 
 function appendNode(
@@ -361,6 +378,9 @@ export function parseMarkdownHierarchy(
         ...(commentAttrs?.userPublicKey !== undefined && {
           userPublicKey: commentAttrs.userPublicKey,
         }),
+        ...(commentAttrs?.nodeKind !== undefined && {
+          nodeKind: commentAttrs.nodeKind,
+        }),
       };
       appendNode(roots, parent, node);
       headingStack.push({ level: headingLevel, node });
@@ -428,6 +448,9 @@ export function parseMarkdownHierarchy(
           ...(commentAttrs?.userPublicKey !== undefined && {
             userPublicKey: commentAttrs.userPublicKey,
           }),
+          ...(commentAttrs?.nodeKind !== undefined && {
+            nodeKind: commentAttrs.nodeKind,
+          }),
         };
         appendNode(roots, parent, node);
         listItemStack[currentItemIndex] = node;
@@ -440,6 +463,9 @@ export function parseMarkdownHierarchy(
         ...(linkHref !== undefined && { linkHref }),
         ...(relevance !== undefined && { relevance }),
         ...(argument !== undefined && { argument }),
+        ...(commentAttrs?.nodeKind !== undefined && {
+          nodeKind: commentAttrs.nodeKind,
+        }),
       });
       continue;
     }
@@ -448,6 +474,9 @@ export function parseMarkdownHierarchy(
       text,
       children: [],
       blockKind: "paragraph",
+      ...(commentAttrs?.nodeKind !== undefined && {
+        nodeKind: commentAttrs.nodeKind,
+      }),
     };
     appendNode(
       roots,

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -96,6 +96,42 @@ function parseTypeFilters(
     );
 }
 
+function parseNodeKind(value: string): NodeKind | undefined {
+  if (
+    value === "topic" ||
+    value === "author" ||
+    value === "source" ||
+    value === "statement" ||
+    value === "task"
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function parseNodeKindFilters(arr: Array<Serializable>): NodeKind[] {
+  return arr
+    .map((item) => parseNodeKind(asString(item)))
+    .filter((parsed): parsed is NodeKind => parsed !== undefined);
+}
+
+function parseLegacySemanticViewMode(value: string): NodeKind[] | undefined {
+  const nodeKind = parseNodeKind(value);
+  return nodeKind ? [nodeKind] : undefined;
+}
+
+function parsePaneNodeKindFilters(obj: {
+  [key: string]: Serializable;
+}): NodeKind[] | undefined {
+  if (obj.k !== undefined) {
+    return parseNodeKindFilters(asArray(obj.k));
+  }
+  if (obj.m !== undefined) {
+    return parseLegacySemanticViewMode(asString(obj.m));
+  }
+  return undefined;
+}
+
 function viewToJSON(attributes: View): Serializable {
   return {
     e: attributes.expanded !== undefined ? attributes.expanded : undefined,
@@ -141,6 +177,7 @@ export function paneToJSON(pane: Pane): Serializable {
     a: pane.author,
     r: pane.rootNodeId,
     t: pane.typeFilters,
+    k: pane.nodeKindFilters,
   };
 }
 
@@ -158,6 +195,7 @@ function jsonToPane(s: Serializable): Pane | undefined {
       obj.t !== undefined
         ? (asArray(obj.t).map((f) => asString(f)) as Pane["typeFilters"])
         : undefined,
+    nodeKindFilters: parsePaneNodeKindFilters(obj),
   };
 }
 

--- a/src/treeTraversal.test.ts
+++ b/src/treeTraversal.test.ts
@@ -1,0 +1,171 @@
+import { List, Map } from "immutable";
+import { getNode } from "./connections";
+import { parseDocumentContent } from "./markdownNodes";
+import { renderDocumentMarkdown } from "./documentRenderer";
+import { getNodesInTree } from "./treeTraversal";
+import { ViewPath, viewPathToString } from "./ViewContext";
+import { ALICE, applyDefaults } from "./utils.test";
+
+const TEST_MARKDOWN = `# Root <!-- id:root nodeKind="topic" -->
+- Topic <!-- id:topic nodeKind="topic" -->
+  - Author <!-- id:author nodeKind="author" -->
+    - Work <!-- id:work nodeKind="source" -->
+      - (!) Thesis <!-- id:thesis nodeKind="statement" -->
+        - Detail <!-- id:detail nodeKind="statement" -->
+  - Empty Author <!-- id:empty-author nodeKind="author" -->
+    - Empty Work <!-- id:empty-work nodeKind="source" -->
+`;
+
+function getRequiredNode(
+  nodes: Map<string, GraphNode>,
+  text: string
+): GraphNode {
+  const node = nodes.find((candidate) => candidate.text === text);
+  if (!node) {
+    throw new Error(`Missing node ${text}`);
+  }
+  return node;
+}
+
+function buildKnowledgeDBs(
+  nodes: Map<string, GraphNode>
+): Map<PublicKey, KnowledgeData> {
+  return Map<PublicKey, KnowledgeData>({
+    [ALICE.publicKey]: { nodes },
+  });
+}
+
+function collectExpandedViews(
+  knowledgeDBs: KnowledgeDBs,
+  node: GraphNode,
+  path: ViewPath,
+  views: Views = Map<string, View>()
+): Views {
+  const withCurrent =
+    node.children.size > 0
+      ? views.set(viewPathToString(path), { expanded: true })
+      : views;
+  return node.children.reduce((acc, childID) => {
+    const child = getNode(knowledgeDBs, childID, ALICE.publicKey);
+    return child
+      ? collectExpandedViews(
+          knowledgeDBs,
+          child,
+          [...path, child.id] as ViewPath,
+          acc
+        )
+      : acc;
+  }, withCurrent);
+}
+
+function buildData(nodeKindFilters: NodeKind[] | undefined): {
+  data: Data;
+  rootPath: ViewPath;
+} {
+  const nodes = parseDocumentContent({
+    content: TEST_MARKDOWN,
+    author: ALICE.publicKey,
+  });
+  const root = getRequiredNode(nodes, "Root");
+  const rootPath = [0, root.id] as ViewPath;
+  const knowledgeDBs = buildKnowledgeDBs(nodes);
+  const views = collectExpandedViews(knowledgeDBs, root, rootPath);
+  return {
+    rootPath,
+    data: applyDefaults({
+      knowledgeDBs,
+      views,
+      panes: [
+        {
+          id: "pane-0",
+          stack: [],
+          author: ALICE.publicKey,
+          nodeKindFilters,
+        },
+      ],
+    }),
+  };
+}
+
+function visibleRows(filters: NodeKind[]): { text: string; depth: number }[] {
+  const { data, rootPath } = buildData(filters);
+  const result = getNodesInTree(
+    data,
+    rootPath,
+    [],
+    List<ViewPath>(),
+    undefined,
+    ALICE.publicKey,
+    undefined,
+    filters
+  );
+  return result.paths
+    .map((path) => {
+      const key = viewPathToString(path);
+      const node = getNode(
+        data.knowledgeDBs,
+        path[path.length - 1] as ID,
+        ALICE.publicKey
+      );
+      return {
+        text: node?.text || "",
+        depth: result.displayDepths.get(key) ?? path.length - 1,
+      };
+    })
+    .toArray();
+}
+
+test("nodeKind imports and exports through markdown comments", () => {
+  const nodes = parseDocumentContent({
+    content: TEST_MARKDOWN,
+    author: ALICE.publicKey,
+  });
+  const root = getRequiredNode(nodes, "Root");
+  const author = getRequiredNode(nodes, "Author");
+  const work = getRequiredNode(nodes, "Work");
+  const thesis = getRequiredNode(nodes, "Thesis");
+  // eslint-disable-next-line testing-library/render-result-naming-convention
+  const markdownText = renderDocumentMarkdown(buildKnowledgeDBs(nodes), root);
+
+  expect(root.nodeKind).toBe("topic");
+  expect(author.nodeKind).toBe("author");
+  expect(work.nodeKind).toBe("source");
+  expect(thesis.nodeKind).toBe("statement");
+  expect(markdownText).toContain('nodeKind="topic"');
+  expect(markdownText).toContain('nodeKind="author"');
+  expect(markdownText).toContain('nodeKind="source"');
+  expect(markdownText).toContain('nodeKind="statement"');
+});
+
+test("node kind topic filter shows topics only", () => {
+  expect(visibleRows(["topic"])).toEqual([{ text: "Topic", depth: 2 }]);
+});
+
+test("node kind author filter lifts authors when topics are hidden", () => {
+  expect(visibleRows(["author"])).toEqual([
+    { text: "Author", depth: 2 },
+    { text: "Empty Author", depth: 2 },
+  ]);
+});
+
+test("combined topic and author filters keep topic context", () => {
+  expect(visibleRows(["topic", "author"])).toEqual([
+    { text: "Topic", depth: 2 },
+    { text: "Author", depth: 3 },
+    { text: "Empty Author", depth: 3 },
+  ]);
+});
+
+test("node kind source filter skips authors and lifts works", () => {
+  expect(visibleRows(["source"])).toEqual([
+    { text: "Work", depth: 2 },
+    { text: "Empty Work", depth: 2 },
+  ]);
+});
+
+test("node kind statement filter skips authors and sources", () => {
+  expect(visibleRows(["statement"])).toEqual([
+    { text: "Thesis", depth: 2 },
+    { text: "Detail", depth: 3 },
+  ]);
+});

--- a/src/treeTraversal.ts
+++ b/src/treeTraversal.ts
@@ -31,6 +31,7 @@ export type TreeResult = {
   paths: List<ViewPath>;
   virtualRows: VirtualRowsMap;
   firstVirtualKeys: ImmutableSet<string>;
+  displayDepths: Map<string, number>;
 };
 
 type TreeTraversalOptions = {
@@ -39,6 +40,29 @@ type TreeTraversalOptions = {
 
 const EMPTY_VIRTUAL_ROWS: VirtualRowsMap = Map<string, GraphNode>();
 const EMPTY_FIRST_VIRTUAL_KEYS: ImmutableSet<string> = ImmutableSet<string>();
+const EMPTY_DISPLAY_DEPTHS: Map<string, number> = Map<string, number>();
+
+function emptyTreeResult(): TreeResult {
+  return {
+    paths: List<ViewPath>(),
+    virtualRows: EMPTY_VIRTUAL_ROWS,
+    firstVirtualKeys: EMPTY_FIRST_VIRTUAL_KEYS,
+    displayDepths: EMPTY_DISPLAY_DEPTHS,
+  };
+}
+
+function isNodeKindFilterActive(
+  nodeKindFilters: Pane["nodeKindFilters"]
+): nodeKindFilters is NodeKind[] {
+  return nodeKindFilters !== undefined;
+}
+
+function nodeMatchesKindFilters(
+  node: GraphNode,
+  nodeKindFilters: NodeKind[]
+): boolean {
+  return !!node.nodeKind && nodeKindFilters.includes(node.nodeKind);
+}
 
 function getChildrenForConcreteRef(
   data: Data,
@@ -52,11 +76,7 @@ function getChildrenForConcreteRef(
       ? resolveNode(data.knowledgeDBs, refNode)
       : getNode(data.knowledgeDBs, parentRowID, data.user.publicKey);
   if (!sourceNode || sourceNode.children.size === 0) {
-    return {
-      paths: List(),
-      virtualRows: EMPTY_VIRTUAL_ROWS,
-      firstVirtualKeys: EMPTY_FIRST_VIRTUAL_KEYS,
-    };
+    return emptyTreeResult();
   }
 
   return {
@@ -65,7 +85,115 @@ function getChildrenForConcreteRef(
       .toList(),
     virtualRows: EMPTY_VIRTUAL_ROWS,
     firstVirtualKeys: EMPTY_FIRST_VIRTUAL_KEYS,
+    displayDepths: EMPTY_DISPLAY_DEPTHS,
   };
+}
+
+function getSemanticNodeChildren(
+  data: Data,
+  parentPath: ViewPath,
+  nodes: GraphNode,
+  activeFilters: NonNullable<Pane["typeFilters"]>,
+  nodeKindFilters: NodeKind[]
+): List<ViewPath> {
+  const descendantMemo = new globalThis.Map<string, boolean>();
+  const visiting = new globalThis.Set<string>();
+
+  const getFilteredChildEntries = (
+    parent: GraphNode
+  ): { childPath: ViewPath; childNode: GraphNode }[] =>
+    parent.children
+      .map((childID, index) => ({
+        childID,
+        childNode:
+          childID === EMPTY_SEMANTIC_ID
+            ? undefined
+            : getNode(data.knowledgeDBs, childID, data.user.publicKey),
+        index,
+      }))
+      .filter(
+        (
+          entry
+        ): entry is {
+          childID: ID;
+          childNode: GraphNode;
+          index: number;
+        } =>
+          !!entry.childNode && itemPassesFilters(entry.childNode, activeFilters)
+      )
+      .map(({ childNode, index }) => ({
+        childNode,
+        childPath: addNodeToPathWithNodes(parentPath, parent, index),
+      }))
+      .toArray();
+
+  const getEntriesForPath = (
+    path: ViewPath,
+    parent: GraphNode
+  ): { childPath: ViewPath; childNode: GraphNode }[] =>
+    parent.children
+      .map((childID, index) => ({
+        childID,
+        childNode:
+          childID === EMPTY_SEMANTIC_ID
+            ? undefined
+            : getNode(data.knowledgeDBs, childID, data.user.publicKey),
+        index,
+      }))
+      .filter(
+        (
+          entry
+        ): entry is {
+          childID: ID;
+          childNode: GraphNode;
+          index: number;
+        } =>
+          !!entry.childNode && itemPassesFilters(entry.childNode, activeFilters)
+      )
+      .map(({ childNode, index }) => ({
+        childNode,
+        childPath: addNodeToPathWithNodes(path, parent, index),
+      }))
+      .toArray();
+
+  const hasMatchingDescendant = (path: ViewPath, node: GraphNode): boolean => {
+    const key = viewPathToString(path);
+    const cached = descendantMemo.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(key)) {
+      return false;
+    }
+    visiting.add(key);
+    const found = getEntriesForPath(path, node).some(
+      ({ childPath, childNode }) =>
+        nodeMatchesKindFilters(childNode, nodeKindFilters) ||
+        hasMatchingDescendant(childPath, childNode)
+    );
+    visiting.delete(key);
+    descendantMemo.set(key, found);
+    return found;
+  };
+
+  const collectFromNode = (path: ViewPath, node: GraphNode): ViewPath[] =>
+    getEntriesForPath(path, node).flatMap(({ childPath, childNode }) => {
+      if (nodeMatchesKindFilters(childNode, nodeKindFilters)) {
+        return [childPath];
+      }
+      return collectFromNode(childPath, childNode);
+    });
+
+  return List(
+    getFilteredChildEntries(nodes).flatMap(({ childPath, childNode }) => {
+      if (nodeMatchesKindFilters(childNode, nodeKindFilters)) {
+        return [childPath];
+      }
+      return hasMatchingDescendant(childPath, childNode)
+        ? collectFromNode(childPath, childNode)
+        : [];
+    })
+  );
 }
 
 function getChildrenForRegularNode(
@@ -76,6 +204,7 @@ function getChildrenForRegularNode(
   rootNode: LongID | undefined,
   author: PublicKey,
   typeFilters: Pane["typeFilters"],
+  nodeKindFilters: Pane["nodeKindFilters"],
   options?: TreeTraversalOptions
 ): TreeResult {
   const effectiveAuthor = getEffectiveAuthor(data, parentPath);
@@ -92,31 +221,44 @@ function getChildrenForRegularNode(
     : parentRowID;
   const coordinateSemanticID = nodes ? nodeSemanticID : parentRowID;
 
-  const nodePaths = nodes
-    ? nodes.children
-        .map((childID, index) => ({
-          childID,
-          childNode:
-            childID === EMPTY_SEMANTIC_ID
-              ? undefined
-              : getNode(data.knowledgeDBs, childID, data.user.publicKey),
-          index,
-        }))
-        .filter(({ childID, childNode }) =>
-          options?.isMarkdownExport
-            ? !!childNode
-            : childID === EMPTY_SEMANTIC_ID ||
-              (!!childNode && itemPassesFilters(childNode, activeFilters))
-        )
-        .map(({ index }) => addNodeToPathWithNodes(parentPath, nodes, index))
-        .toList()
-    : List<ViewPath>();
+  const nodePaths = (() => {
+    if (!nodes) {
+      return List<ViewPath>();
+    }
+    if (isNodeKindFilterActive(nodeKindFilters) && !options?.isMarkdownExport) {
+      return getSemanticNodeChildren(
+        data,
+        parentPath,
+        nodes,
+        activeFilters,
+        nodeKindFilters
+      );
+    }
+    return nodes.children
+      .map((childID, index) => ({
+        childID,
+        childNode:
+          childID === EMPTY_SEMANTIC_ID
+            ? undefined
+            : getNode(data.knowledgeDBs, childID, data.user.publicKey),
+        index,
+      }))
+      .filter(({ childID, childNode }) =>
+        options?.isMarkdownExport
+          ? !!childNode
+          : childID === EMPTY_SEMANTIC_ID ||
+            (!!childNode && itemPassesFilters(childNode, activeFilters))
+      )
+      .map(({ index }) => addNodeToPathWithNodes(parentPath, nodes, index))
+      .toList();
+  })();
 
-  if (options?.isMarkdownExport) {
+  if (options?.isMarkdownExport || isNodeKindFilterActive(nodeKindFilters)) {
     return {
       paths: nodePaths,
       virtualRows: EMPTY_VIRTUAL_ROWS,
       firstVirtualKeys: EMPTY_FIRST_VIRTUAL_KEYS,
+      displayDepths: EMPTY_DISPLAY_DEPTHS,
     };
   }
 
@@ -232,6 +374,7 @@ function getChildrenForRegularNode(
     paths: nodePaths.concat(withVersions.paths),
     virtualRows: withVersions.virtualRows,
     firstVirtualKeys,
+    displayDepths: EMPTY_DISPLAY_DEPTHS,
   };
 }
 
@@ -242,6 +385,7 @@ export function getTreeChildren(
   rootNode: LongID | undefined,
   author: PublicKey,
   typeFilters: Pane["typeFilters"],
+  nodeKindFilters: Pane["nodeKindFilters"],
   options?: TreeTraversalOptions,
   virtualRows: VirtualRowsMap = EMPTY_VIRTUAL_ROWS
 ): TreeResult {
@@ -267,6 +411,7 @@ export function getTreeChildren(
     rootNode,
     author,
     typeFilters,
+    nodeKindFilters,
     options
   );
 }
@@ -279,8 +424,10 @@ export function getNodesInTree(
   rootNode: LongID | undefined,
   author: PublicKey,
   typeFilters: Pane["typeFilters"],
+  nodeKindFilters: Pane["nodeKindFilters"],
   options?: TreeTraversalOptions,
-  virtualRows: VirtualRowsMap = EMPTY_VIRTUAL_ROWS
+  virtualRows: VirtualRowsMap = EMPTY_VIRTUAL_ROWS,
+  displayDepths: Map<string, number> = EMPTY_DISPLAY_DEPTHS
 ): TreeResult {
   const childResult = getTreeChildren(
     data,
@@ -289,6 +436,7 @@ export function getNodesInTree(
     rootNode,
     author,
     typeFilters,
+    nodeKindFilters,
     options,
     virtualRows
   );
@@ -297,6 +445,18 @@ export function getNodesInTree(
     (result, childPath) => {
       const [, childView] = getRowIDFromView(data, childPath);
       const withChild = result.paths.push(childPath);
+      const nodeKindFilterActive = isNodeKindFilterActive(nodeKindFilters);
+      const parentDepth =
+        result.displayDepths.get(viewPathToString(parentPath)) ??
+        parentPath.length - 1;
+      const childKey = viewPathToString(childPath);
+      const childDisplayDepth = nodeKindFilterActive
+        ? parentDepth + 1
+        : childPath.length - 1;
+      const withDisplayDepths = result.displayDepths.set(
+        childKey,
+        childDisplayDepth
+      );
 
       const childEdge =
         result.virtualRows.get(viewPathToString(childPath)) ||
@@ -313,21 +473,25 @@ export function getNodesInTree(
           rootNode,
           author,
           typeFilters,
+          nodeKindFilters,
           options,
-          result.virtualRows
+          result.virtualRows,
+          withDisplayDepths
         );
         return {
           paths: sub.paths,
           virtualRows: result.virtualRows.merge(sub.virtualRows),
           firstVirtualKeys: result.firstVirtualKeys.union(sub.firstVirtualKeys),
+          displayDepths: sub.displayDepths,
         };
       }
-      return { ...result, paths: withChild };
+      return { ...result, paths: withChild, displayDepths: withDisplayDepths };
     },
     {
       paths: ctx,
       virtualRows: childResult.virtualRows,
       firstVirtualKeys: childResult.firstVirtualKeys,
+      displayDepths,
     }
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,7 @@ declare global {
       | "incoming"
       | "contains"
     )[];
+    nodeKindFilters?: NodeKind[];
     scrollToId?: string;
   };
 
@@ -208,6 +209,8 @@ declare global {
   // Argument types (evidence) for node children
   type Argument = "confirms" | "contra" | undefined;
 
+  type NodeKind = "topic" | "author" | "source" | "statement" | "task";
+
   // Each item in a node has relevance and optional argument
   type VirtualType = "suggestion" | "search" | "incoming" | "version";
 
@@ -251,6 +254,7 @@ declare global {
     isCref?: boolean;
     targetID?: LongID;
     linkText?: string;
+    nodeKind?: NodeKind;
     blockKind?: "heading" | "list_item" | "paragraph";
     headingLevel?: number;
     listOrdered?: boolean;


### PR DESCRIPTION
## Status
Draft only. Do not merge/review as a standalone change yet.

This PR is stacked on #219 (`Document semantic marker draft suffixes`) and is intentionally exploratory until the node-kind boundary is confirmed. GitHub will show #219's commits in this comparison until that base PR lands or this branch is rebased.

## Important boundary note
knowstr did not previously have a general implemented node-type model. Existing concepts are separate axes:
- `Relevance` / `Argument` for marker semantics
- `VirtualType` for generated rows such as suggestions, incoming refs, versions
- `blockKind` for markdown block shape
- `NodeType` exists as a type alias but is not an implemented node-kind system

This PR adds a minimal hidden `nodeKind` classification for filtering only. It is not intended to introduce relation types or a broad ontology.

## Summary
- Adds schema-light `nodeKind` support for topic, author, source, statement, and task nodes.
- Adds additive node-kind filters with compact icons.
- Keeps real `ViewPath`s intact while visually lifting matching descendants when intermediate nodes are filtered out.
- Preserves legacy serialized `semanticViewMode` values by mapping them into `nodeKindFilters` on load.

## Intended split before merge
This should be split or rebased before real review:
1. Minimal model/Markdown roundtrip for `nodeKind`.
2. Tree traversal lifting for filtered node kinds.
3. Header UI icons and pane-state persistence.

## Out of scope
- No relation types.
- No broad product-data model.
- No changes to `electron/main.js`.

## Validation already run locally
- `npm run typescript`
- `npm test -- --runTestsByPath src/treeTraversal.test.ts src/components/TypeFilterButton.test.tsx --runInBand`
- `npm test -- --runTestsByPath src/components/TypeFilterButton.test.tsx src/components/Multiselect.test.tsx src/components/ViewStatePreservation.test.tsx src/dnd.test.tsx --runInBand`
- `npx eslint src/types.ts src/constants.ts src/markdownTree.ts src/treeTraversal.ts src/treeTraversal.test.ts src/serializer.tsx src/components/TreeView.tsx src/components/Node.tsx src/dnd.tsx src/components/TypeFilterButton.tsx src/components/TypeFilterButton.test.tsx`
- `git diff --check`
