### PR TITLE
Add explicit node kind metadata roundtrip

### DIFF
--- a/src/cli/save.test.ts
+++ b/src/cli/save.test.ts
@@ -276,6 +276,42 @@ test("save preserves ordered lists", async () => {
   expect((await knowstrSave(workspaceDir)).changed_paths).toEqual([]);
 });
 
+test("save round-trips explicit node kind comments", async () => {
+  const { path: workspaceDir } = knowstrInit();
+  write(
+    workspaceDir,
+    "ebibliothek.md",
+    `
+# Praxis <!-- id:topic-praxis nodeKind="topic" -->
+- Rahim Taghizadegan <!-- id:person-rahim nodeKind="person" -->
+  - Seminar 40 <!-- id:source-seminar-40 nodeKind="source" -->
+    - Proof of work limits cheap identity claims. <!-- id:statement-pow nodeKind="statement" -->
+    - Review transcript gate <!-- id:task-transcript nodeKind="task" -->
+`
+  );
+
+  await knowstrSave(workspaceDir);
+
+  const raw = fs.readFileSync(
+    path.join(workspaceDir, "ebibliothek.md"),
+    "utf8"
+  );
+  expect(raw).toContain('# Praxis <!-- id:topic-praxis nodeKind="topic" -->');
+  expect(raw).toContain(
+    '- Rahim Taghizadegan <!-- id:person-rahim nodeKind="person" -->'
+  );
+  expect(raw).toContain(
+    '  - Seminar 40 <!-- id:source-seminar-40 nodeKind="source" -->'
+  );
+  expect(raw).toContain(
+    '    - Proof of work limits cheap identity claims. <!-- id:statement-pow nodeKind="statement" -->'
+  );
+  expect(raw).toContain(
+    '    - Review transcript gate <!-- id:task-transcript nodeKind="task" -->'
+  );
+  expect((await knowstrSave(workspaceDir)).changed_paths).toEqual([]);
+});
+
 test("save preserves mixed structure with ordered items and nested bullets", async () => {
   const { path: workspaceDir } = knowstrInit();
   write(

--- a/src/components/MarkdownImportPlan.test.tsx
+++ b/src/components/MarkdownImportPlan.test.tsx
@@ -32,6 +32,20 @@ function flattenTexts(nodes: MarkdownTreeNode[]): string[] {
   }, []);
 }
 
+function findTreeNodeByText(
+  nodes: MarkdownTreeNode[],
+  text: string
+): MarkdownTreeNode | undefined {
+  return nodes.reduce<MarkdownTreeNode | undefined>((found, node) => {
+    return (
+      found ||
+      (spansText(node.spans) === text
+        ? node
+        : findTreeNodeByText(node.children, text))
+    );
+  }, undefined);
+}
+
 function nodeChildren(
   knowledgeDBs: KnowledgeDBs,
   node: GraphNode | undefined,
@@ -211,6 +225,31 @@ test("Parser strips leading list markers and keeps nesting", () => {
 
   const allTexts = flattenTexts(trees);
   expect(allTexts.every((text) => !/^[-+*]|\d+\./u.test(text))).toBe(true);
+});
+
+test("Parser reads explicit node kinds from id comments", () => {
+  const trees = parseMarkdownHierarchy(`
+# Praxis <!-- id:topic-praxis nodeKind="topic" -->
+- Rahim Taghizadegan <!-- id:person-rahim nodeKind="person" -->
+  - Seminar 40 <!-- id:source-seminar-40 nodeKind="source" -->
+    - Proof of work limits cheap identity claims. <!-- id:statement-pow nodeKind="statement" -->
+    - Review transcript gate <!-- id:task-transcript nodeKind="task" -->
+- Unknown kind <!-- id:unknown-kind nodeKind="collection" -->
+`);
+
+  expect(findTreeNodeByText(trees, "Praxis")?.nodeKind).toBe("topic");
+  expect(findTreeNodeByText(trees, "Rahim Taghizadegan")?.nodeKind).toBe(
+    "person"
+  );
+  expect(findTreeNodeByText(trees, "Seminar 40")?.nodeKind).toBe("source");
+  expect(
+    findTreeNodeByText(trees, "Proof of work limits cheap identity claims.")
+      ?.nodeKind
+  ).toBe("statement");
+  expect(findTreeNodeByText(trees, "Review transcript gate")?.nodeKind).toBe(
+    "task"
+  );
+  expect(findTreeNodeByText(trees, "Unknown kind")?.nodeKind).toBeUndefined();
 });
 
 test("Parser turns hard-wrapped list item breaks into spaces", () => {

--- a/src/documentFormat.ts
+++ b/src/documentFormat.ts
@@ -3,10 +3,12 @@ export function formatRootHeading(
   rootUuid: string,
   basedOn?: LongID,
   snapshotDTag?: string,
-  anchor?: RootAnchor
+  anchor?: RootAnchor,
+  nodeKind?: NodeKind
 ): string {
   const parts = [
     `id:${rootUuid}`,
+    ...(nodeKind ? [`nodeKind="${nodeKind}"`] : []),
     ...(basedOn ? [`basedOn="${basedOn}"`] : []),
     ...(snapshotDTag ? [`snapshot="${snapshotDTag}"`] : []),
     ...(anchor?.snapshotContext.size
@@ -35,10 +37,12 @@ export function formatNodeAttrs(
     hidden?: boolean;
     basedOn?: LongID;
     userPublicKey?: PublicKey;
+    nodeKind?: NodeKind;
   }
 ): string {
   const parts: string[] = [
     ...(uuid ? [`id:${uuid}`] : []),
+    ...(options?.nodeKind ? [`nodeKind="${options.nodeKind}"`] : []),
     ...(options?.userPublicKey
       ? [`userPublicKey="${options.userPublicKey}"`]
       : []),

--- a/src/documentRenderer.ts
+++ b/src/documentRenderer.ts
@@ -107,6 +107,7 @@ function serializeNodeItems(
         ...(resolvedChild.userPublicKey
           ? { userPublicKey: resolvedChild.userPublicKey }
           : {}),
+        ...(resolvedChild.nodeKind ? { nodeKind: resolvedChild.nodeKind } : {}),
       });
 
       if (resolvedChild.blockKind === "heading") {
@@ -228,7 +229,8 @@ export function renderDocumentMarkdown(
     rootUuid,
     rootNode.basedOn,
     options?.snapshotDTag ?? rootNode.snapshotDTag,
-    rootNode.anchor ?? createRootAnchor(getNodeContext(knowledgeDBs, rootNode))
+    rootNode.anchor ?? createRootAnchor(getNodeContext(knowledgeDBs, rootNode)),
+    rootNode.nodeKind
   );
   return formatWithFrontMatter(
     `${addBlankLinesAroundHeadings([rootLine, ...serialized.lines]).join(

--- a/src/markdownNodes.ts
+++ b/src/markdownNodes.ts
@@ -66,6 +66,7 @@ function materializeTreeNode(
     userPublicKey: treeNode.userPublicKey,
     snapshotDTag: parent ? undefined : treeNode.snapshotDTag,
     ...(treeNode.blockKind !== undefined && { blockKind: treeNode.blockKind }),
+    ...(treeNode.nodeKind !== undefined && { nodeKind: treeNode.nodeKind }),
     ...(treeNode.headingLevel !== undefined && {
       headingLevel: treeNode.headingLevel,
     }),

--- a/src/markdownTree.ts
+++ b/src/markdownTree.ts
@@ -6,6 +6,7 @@ import markdownItFrontMatter from "markdown-it-front-matter";
 import Token from "markdown-it/lib/token";
 import { fileLinkSpan, linkSpan, plainSpans, spansText } from "./nodeSpans";
 import { isMarkdownPath } from "./linkPath";
+import { parseNodeKind } from "./nodeKind";
 
 const markdown = new MarkdownIt({ html: true });
 markdown.use(markdownItFrontMatter, () => undefined);
@@ -35,6 +36,7 @@ type ParsedComment = {
   anchor: RootAnchor | undefined;
   systemRole: RootSystemRole | undefined;
   userPublicKey: PublicKey | undefined;
+  nodeKind: NodeKind | undefined;
 };
 
 function parseIdComment(content: string): ParsedComment | undefined {
@@ -64,6 +66,7 @@ function parseIdComment(content: string): ParsedComment | undefined {
   const userPublicKey = (attrsMap.userPublicKey || undefined) as
     | PublicKey
     | undefined;
+  const nodeKind = parseNodeKind(attrsMap.nodeKind);
 
   const anchor =
     anchorContext ||
@@ -98,6 +101,7 @@ function parseIdComment(content: string): ParsedComment | undefined {
     anchor,
     systemRole: undefined,
     userPublicKey,
+    nodeKind,
   };
 }
 
@@ -275,6 +279,7 @@ export type MarkdownTreeNode = {
   anchor?: RootAnchor;
   systemRole?: RootSystemRole;
   userPublicKey?: PublicKey;
+  nodeKind?: NodeKind;
 };
 
 function appendNode(
@@ -376,6 +381,9 @@ export function parseMarkdownHierarchy(
         ...(commentAttrs?.userPublicKey !== undefined && {
           userPublicKey: commentAttrs.userPublicKey,
         }),
+        ...(commentAttrs?.nodeKind !== undefined && {
+          nodeKind: commentAttrs.nodeKind,
+        }),
       };
       appendNode(roots, parent, node);
       headingStack.push({ level: headingLevel, node });
@@ -441,6 +449,9 @@ export function parseMarkdownHierarchy(
           ...(commentAttrs?.userPublicKey !== undefined && {
             userPublicKey: commentAttrs.userPublicKey,
           }),
+          ...(commentAttrs?.nodeKind !== undefined && {
+            nodeKind: commentAttrs.nodeKind,
+          }),
         };
         appendNode(roots, parent, node);
         listItemStack[currentItemIndex] = node;
@@ -462,6 +473,9 @@ export function parseMarkdownHierarchy(
         }),
         ...(commentAttrs?.userPublicKey !== undefined && {
           userPublicKey: commentAttrs.userPublicKey,
+        }),
+        ...(commentAttrs?.nodeKind !== undefined && {
+          nodeKind: commentAttrs.nodeKind,
         }),
       });
       continue;
@@ -489,6 +503,9 @@ export function parseMarkdownHierarchy(
       }),
       ...(commentAttrs?.userPublicKey !== undefined && {
         userPublicKey: commentAttrs.userPublicKey,
+      }),
+      ...(commentAttrs?.nodeKind !== undefined && {
+        nodeKind: commentAttrs.nodeKind,
       }),
     };
     appendNode(

--- a/src/nodeKind.ts
+++ b/src/nodeKind.ts
@@ -1,0 +1,16 @@
+export const NODE_KINDS = [
+  "topic",
+  "person",
+  "source",
+  "statement",
+  "task",
+] as const;
+
+export function parseNodeKind(value: string | undefined): NodeKind | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return NODE_KINDS.includes(value as NodeKind)
+    ? (value as NodeKind)
+    : undefined;
+}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -29,8 +29,10 @@ suggestionSettings.maxSuggestions = 3;
 /* eslint-enable functional/immutable-data */
 
 afterEach(() => {
-  if (typeof localStorage !== "undefined") {
-    localStorage.clear();
+  const storage =
+    typeof window !== "undefined" ? window.localStorage : global.localStorage;
+  if (storage && typeof storage.clear === "function") {
+    storage.clear();
   }
   if (typeof window !== "undefined") {
     window.history.pushState({}, "", "/");

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,8 @@ declare global {
   // Argument types (evidence) for node children
   type Argument = "confirms" | "contra" | undefined;
 
+  type NodeKind = "topic" | "person" | "source" | "statement" | "task";
+
   // Each item in a node has relevance and optional argument
   type VirtualType = "suggestion" | "search" | "incoming" | "version";
 
@@ -254,6 +256,7 @@ declare global {
     root: ID;
     relevance: Relevance;
     argument?: Argument;
+    nodeKind?: NodeKind;
     virtualType?: VirtualType;
     versionMeta?: VersionMeta;
     blockKind?: "heading" | "list_item" | "paragraph";

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,17 @@
 # Lessons Learned
 
+## Use `person` for semantic people nodes, not `author`
+
+**Date**: 2026-04-27
+**Context**: While adding a small hidden `nodeKind` foundation, I initially named the people-like node kind `author`.
+
+**Mistake**: In Knowstr, `author` is already a technical Nostr/document authorship field. In the eBibliothek context the semantic entity is broader: authors, speakers, teachers, and other people all belong under `person`.
+
+**Rule**:
+1. Use `person` for semantic human/person nodes.
+2. Reserve `author` for existing technical authorship/public-key ownership fields.
+3. Before naming a new metadata value, check the surrounding product vocabulary and existing field names.
+
 ## Stop when the stated goal is met; don't extrapolate from offhand architectural comments
 
 **Date**: 2026-04-22


### PR DESCRIPTION
## Summary
- add a minimal hidden `NodeKind` field with fixed values: `topic`, `person`, `source`, `statement`, `task`
- parse `nodeKind="..."` only from existing id comments and ignore unknown values
- preserve explicit node kinds when rendering/saving markdown
- prefer `person` over `author` because `author` is already technical Nostr/document ownership vocabulary
- make test cleanup use jsdom `window.localStorage` when available so Node 25 localStorage does not break CLI tests

## Non-goals
- no UI controls
- no filter behavior
- no sorting behavior
- no relation types
- no guessing node kinds from labels or structure

## Tests
- `npm test -- --runTestsByPath src/components/MarkdownImportPlan.test.tsx src/cli/save.test.ts src/desktop/FilesystemWriteThrough.test.tsx --runInBand`
- `npm run typescript`
- `npm run lint`
- `npm test -- --runInBand` (70 suites, 786 passed, 105 skipped)
