### PR TITLE
Fix markdown import into empty root

### DIFF
--- a/src/editor/DroppableContainer.tsx
+++ b/src/editor/DroppableContainer.tsx
@@ -78,10 +78,11 @@ function getFilesFromNativeDrop(item: NativeFileDropItem): File[] {
   return Array.from(files);
 }
 
-function planMaterializeImportedRoot(
+export function planMaterializeImportedRoot(
   plan: Plan,
   paneIndex: number,
-  rootItemID: ID
+  rootItemID: ID,
+  rootNodeID: LongID
 ): Plan {
   const updatedPanes = plan.panes.map((paneState, idx) => {
     if (idx !== paneIndex) {
@@ -90,7 +91,7 @@ function planMaterializeImportedRoot(
     return {
       ...paneState,
       stack: [rootItemID],
-      rootNodeId: undefined,
+      rootNodeId: rootNodeID,
     };
   });
   return planUpdatePanes(plan, updatedPanes);
@@ -385,9 +386,6 @@ export function useDroppable({
       clearDropIndent();
       const rawDirection = calcDragDirection(ref, monitor, path);
       const direction = rawDirection;
-      if (isListItem && direction === undefined) {
-        return item;
-      }
 
       if (monitor.getItemType() === NativeTypes.FILE) {
         const fileDropItem = item as NativeFileDropItem;
@@ -426,14 +424,20 @@ export function useDroppable({
             if (!rootTree) {
               return;
             }
-            const [planWithMarkdown, topItemIDs] =
+            const [planWithMarkdown, topItemIDs, topNodeIDs] =
               planCreateNodesFromMarkdownTrees(plan, [rootTree]);
             const rootItemID = topItemIDs[0];
-            if (!rootItemID) {
+            const rootNodeID = topNodeIDs[0];
+            if (!rootItemID || !rootNodeID) {
               return;
             }
             await executePlan(
-              planMaterializeImportedRoot(planWithMarkdown, path[0], rootItemID)
+              planMaterializeImportedRoot(
+                planWithMarkdown,
+                path[0],
+                rootItemID,
+                rootNodeID
+              )
             );
             return;
           }
@@ -448,6 +452,10 @@ export function useDroppable({
             )
           );
         })();
+        return item;
+      }
+
+      if (isListItem && direction === undefined) {
         return item;
       }
 

--- a/src/editor/MarkdownImportPlan.test.tsx
+++ b/src/editor/MarkdownImportPlan.test.tsx
@@ -22,6 +22,7 @@ import {
   planCreateNodesFromMarkdownFiles,
   planCreateNodesFromMarkdownTrees,
 } from "./FileDropZone";
+import { planMaterializeImportedRoot } from "./DroppableContainer";
 import { MarkdownTreeNode, parseMarkdownHierarchy } from "../core/markdownTree";
 import { nodeText, plainSpans, spansText } from "../core/nodeSpans";
 
@@ -305,6 +306,26 @@ test("planCreateNodesFromMarkdownTrees creates only standalone nodes", () => {
     nodeChildren(plan.knowledgeDBs, childNode, plan.user.publicKey).first()?.id
   ).toEqual(grandchildNode?.id);
   expect(grandchildNode && nodeText(grandchildNode)).toBe("Grandchild");
+});
+
+test("empty-root markdown import points pane at imported root node", () => {
+  const [alice] = setup([ALICE]);
+  const basePlan = createPlan(alice());
+
+  const trees = parseMarkdownImportFiles([
+    { name: "smoke.md", markdown: "# Smoke\n\n- A\n  - B" },
+  ]);
+  const [planWithMarkdown, topItemIDs, topNodeIDs] =
+    planCreateNodesFromMarkdownTrees(basePlan, trees);
+  const materialized = planMaterializeImportedRoot(
+    planWithMarkdown,
+    0,
+    topItemIDs[0] as ID,
+    topNodeIDs[0] as LongID
+  );
+
+  expect(materialized.panes[0].stack).toEqual(["Smoke"]);
+  expect(materialized.panes[0].rootNodeId).toEqual(topNodeIDs[0]);
 });
 
 test("Planning multiple markdown files returns top nodes in import order", () => {


### PR DESCRIPTION
## Summary
- keep the imported root node id on the pane when markdown is dropped into an empty root
- prevents the pane from resolving only by semantic text before the imported root is addressable
- covers the empty-root import path with a focused test

## Test
- npm test -- --runTestsByPath src/editor/MarkdownImportPlan.test.tsx --watchAll=false