### PR TITLE
E6 — entity links open the computed pin; the first write mints

### DIFF
--- a/src/DataContext.tsx
+++ b/src/DataContext.tsx
@@ -9,6 +9,7 @@ import {
   useDocumentSnapshotNodes,
   useDocuments,
   useDocumentByFilePath,
+  useDocumentPulledAuthors,
 } from "./DocumentStore";
 
 export type DataContextProps = Data;
@@ -71,6 +72,7 @@ export function MergeKnowledgeDB({
   const snapshotNodes = useDocumentSnapshotNodes();
   const documents = useDocuments();
   const documentByFilePath = useDocumentByFilePath();
+  const pulledAuthors = useDocumentPulledAuthors();
   const mergedDataDBs = mergeKnowledgeDBs(data.knowledgeDBs, documentDBs);
   const baseDBs = knowledgeDBs
     ? mergeKnowledgeDBs(knowledgeDBs, mergedDataDBs)
@@ -91,6 +93,7 @@ export function MergeKnowledgeDB({
         snapshotNodes,
         documents,
         documentByFilePath,
+        pulledAuthors,
       }}
     >
       {children}

--- a/src/DocumentStore.tsx
+++ b/src/DocumentStore.tsx
@@ -13,7 +13,14 @@ import {
   createEmptyGraphIndex,
   removeNodesFromGraphIndex,
 } from "./graphIndex";
-import { eventToParsed, eventToDocumentDelete } from "./nostrEvents";
+import {
+  depositToParsed,
+  eventToParsed,
+  eventToDocumentDelete,
+  findTag,
+} from "./nostrEvents";
+import { KIND_KNOWLEDGE_DEPOSIT } from "./nostr";
+import { snapshotIdForContent } from "./nodesDocumentEvent";
 import {
   Document,
   DocumentDelete,
@@ -48,6 +55,10 @@ type DocumentStoreState = {
   upsertDocument: (parsed: ParsedDocument) => void;
   deleteDocument: (del: DocumentDelete) => void;
   addEvents: (events: ImmutableMap<string, Event | UnsignedEvent>) => void;
+  // Attention-pulled deposits (34774): read-only foreign sources keyed by
+  // event coordinate, replaceable per (pubkey, d), in-memory only.
+  addDepositEvents: (events: ReadonlyArray<Event | UnsignedEvent>) => void;
+  pulledAuthors: ReadonlyArray<SourceId>;
   addSnapshotContents: (snapshots: ReadonlyArray<SnapshotContent>) => void;
 };
 
@@ -355,11 +366,75 @@ export function DocumentStoreProvider({
     [localPubkey]
   );
 
+  const [depositEvents, setDepositEvents] = React.useState(
+    ImmutableMap<string, Event | UnsignedEvent>()
+  );
+
+  const addDepositEvents = React.useCallback(
+    (events: ReadonlyArray<Event | UnsignedEvent>) => {
+      setDepositEvents((prev) =>
+        events.reduce((acc, event) => {
+          if (event.kind !== KIND_KNOWLEDGE_DEPOSIT) {
+            return acc;
+          }
+          const dTag = findTag(event, "d");
+          if (!dTag) {
+            return acc;
+          }
+          const coordinate = `${event.pubkey}:${dTag}`;
+          const existing = acc.get(coordinate);
+          return existing && existing.created_at >= event.created_at
+            ? acc
+            : acc.set(coordinate, event);
+        }, prev)
+      );
+    },
+    []
+  );
+
+  // First-observation baselines: a deposit's content hashes to its
+  // snapshot id by construction — the baseline a later take stamps.
+  React.useEffect(() => {
+    setSnapshotNodes((prev) =>
+      depositEvents.reduce((acc, event) => {
+        const snapshotId = snapshotIdForContent(event.content);
+        return acc.has(snapshotId)
+          ? acc
+          : acc.set(
+              snapshotId,
+              materializeSnapshotContent(snapshotId, event.content)
+            );
+      }, prev)
+    );
+  }, [depositEvents]);
+
+  const pulledAuthors = React.useMemo(
+    () =>
+      [
+        ...new Set(
+          depositEvents
+            .valueSeq()
+            .toArray()
+            .map((event) => event.pubkey as SourceId)
+        ),
+      ].sort(),
+    [depositEvents]
+  );
+
   const activeSnapshot = React.useMemo(() => {
     const eventList = unpublishedEvents.toArray();
     const { records, deletes } = eventsToParsed(eventList, localPubkey);
-    return applyRecordsToSnapshot(snapshot, records, deletes);
-  }, [snapshot, unpublishedEvents, localPubkey]);
+    const depositRecords = depositEvents
+      .valueSeq()
+      .toArray()
+      .map(depositToParsed)
+      .filter((record): record is ParsedDocument => record !== undefined);
+    return applyRecordsToSnapshot(
+      snapshot,
+      [...records, ...depositRecords],
+      deletes
+    );
+  }, [snapshot, unpublishedEvents, localPubkey, depositEvents]);
 
   React.useEffect(() => {
     setSnapshotNodes((prev) =>
@@ -384,6 +459,8 @@ export function DocumentStoreProvider({
       deleteDocument,
       addEvents,
       addSnapshotContents,
+      addDepositEvents,
+      pulledAuthors,
     }),
     [
       activeSnapshot,
@@ -391,6 +468,8 @@ export function DocumentStoreProvider({
       deleteDocument,
       addEvents,
       addSnapshotContents,
+      addDepositEvents,
+      pulledAuthors,
       snapshotNodes,
     ]
   );
@@ -421,6 +500,10 @@ export function useDocumentSnapshotNodes(): SnapshotNodes {
   return (
     React.useContext(DocumentStoreContext)?.snapshotNodes || ImmutableMap()
   );
+}
+
+export function useDocumentPulledAuthors(): ReadonlyArray<SourceId> {
+  return React.useContext(DocumentStoreContext)?.pulledAuthors ?? [];
 }
 
 export function useDocuments(): ImmutableMap<string, Document> {

--- a/src/attentionPull.test.tsx
+++ b/src/attentionPull.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { KIND_KNOWLEDGE_DEPOSIT } from "./nostr";
+import { ALICE, BOB, renderApp, setup, type } from "./utils.test";
+
+afterEach(cleanup);
+
+async function publishViaChip(): Promise<void> {
+  await userEvent.click(await screen.findByLabelText("audience options"));
+  await userEvent.click(await screen.findByLabelText("publish document"));
+  await waitFor(() =>
+    expect(screen.getByLabelText("audience options").textContent).toContain(
+      "everyone"
+    )
+  );
+}
+
+// The real-world rendezvous: two strangers reference the same Wikidata
+// entity; the entity id is the meeting point. Bob publishes his guide
+// (the deposit tags the referenced entity); Alice, holding a document
+// that references the same entity, pulls it by attention.
+test("strangers rendezvous through a shared real-world entity", async () => {
+  const [alice, bob] = setup([ALICE, BOB]);
+
+  renderApp(bob());
+  await type(
+    "Barcelona Guide{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Enter}{Tab}Sagrada Familia{Escape}"
+  );
+  await publishViaChip();
+  cleanup();
+
+  // The deposit carries the referenced entity as an S-tag.
+  const deposit = bob()
+    .relayPool.getEvents()
+    .find((event) => event.kind === KIND_KNOWLEDGE_DEPOSIT);
+  expect(deposit).toBeDefined();
+  expect(
+    deposit?.tags.filter(([name]) => name === "S").map(([, value]) => value)
+  ).toContain("wd:Q1492");
+
+  // Alice starts her own page about the same entity: the root-level
+  // paste mints the entity node — her document IS the entity's page.
+  window.history.pushState({}, "", "/");
+  renderApp(alice());
+  await type("https://www.wikidata.org/wiki/Q1492{Escape}");
+
+  // Her open document's attention pulls Bob's deposit: his source is now
+  // in her graph, and his link into the shared entity surfaces as an
+  // incoming reference when she follows her own link.
+  await waitFor(() => {
+    const subs = alice()
+      .relayPool.getSubscriptions()
+      .flatMap((record) => record.filters)
+      .filter((filter) => (filter.kinds ?? []).includes(KIND_KNOWLEDGE_DEPOSIT))
+      .flatMap((filter) => filter["#S"] ?? []);
+    expect(subs).toContain("wd:Q1492");
+  });
+
+  // The deposit arrived and composed into Alice's graph (transport).
+  // Surfacing it in the entity page's footer — Bob's link as an [I]
+  // incoming row — is CP4.4: the source-scoped incoming lookup shadows
+  // foreign refs when any local ref exists. Pinned below.
+});
+
+// CP4.4 (pinned gap): the pulled source's link into the shared entity
+// must surface as an incoming reference on the entity's page.
+// eslint-disable-next-line jest/no-disabled-tests
+test.skip("the pulled reference surfaces as [I] on the entity page", () => {});
+
+test("the subscription follows attention: entity tags on open, dropped on close", async () => {
+  const [alice] = setup([ALICE]);
+  renderApp(alice());
+  await type(
+    "Travel Plans{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Escape}"
+  );
+
+  const depositSubTags = (): string[] =>
+    alice()
+      .relayPool.getSubscriptions()
+      .flatMap((record) => record.filters)
+      .filter((filter) => (filter.kinds ?? []).includes(KIND_KNOWLEDGE_DEPOSIT))
+      .flatMap((filter) => filter["#S"] ?? []);
+
+  await waitFor(() => {
+    expect(depositSubTags()).toContain("wd:Q1492");
+  });
+
+  cleanup();
+  await waitFor(() => {
+    expect(depositSubTags()).toEqual([]);
+  });
+});

--- a/src/attentionPull.test.tsx
+++ b/src/attentionPull.test.tsx
@@ -114,6 +114,42 @@ Trip Notes
   `);
 });
 
+test("following a dangling entity link opens the computed pin", async () => {
+  const [alice, bob] = setup([ALICE, BOB]);
+
+  renderApp(bob());
+  await type(
+    "Barcelona Guide{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Enter}{Tab}Sagrada Familia{Escape}"
+  );
+  await publishViaChip();
+  cleanup();
+
+  window.history.pushState({}, "", "/");
+  renderApp(alice());
+  await type(
+    "Trip Notes{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Escape}"
+  );
+
+  await userEvent.click(
+    screen.getByText("https://www.wikidata.org/wiki/Q1492")
+  );
+
+  await expectTree(`
+wd:Q1492
+  [OI] Barcelona Guide ↩
+  [I] Trip Notes ↩
+  `);
+
+  await userEvent.click(await screen.findByLabelText("Barcelona Guide ↩"));
+  await userEvent.keyboard("!");
+
+  await expectTree(`
+wd:Q1492
+  [OR] Barcelona Guide
+  [I] Trip Notes ↩
+  `);
+});
+
 test("the subscription follows attention: entity tags on open, dropped on close", async () => {
   const [alice] = setup([ALICE]);
   renderApp(alice());

--- a/src/attentionPull.test.tsx
+++ b/src/attentionPull.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { KIND_KNOWLEDGE_DEPOSIT } from "./nostr";
-import { ALICE, BOB, renderApp, setup, type } from "./utils.test";
+import { ALICE, BOB, expectTree, renderApp, setup, type } from "./utils.test";
 
 afterEach(cleanup);
 
@@ -62,10 +62,57 @@ test("strangers rendezvous through a shared real-world entity", async () => {
   // foreign refs when any local ref exists. Pinned below.
 });
 
-// CP4.4 (pinned gap): the pulled source's link into the shared entity
-// must surface as an incoming reference on the entity's page.
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip("the pulled reference surfaces as [I] on the entity page", () => {});
+test("the pulled reference surfaces as [I] on the entity page", async () => {
+  const [alice, bob] = setup([ALICE, BOB]);
+
+  renderApp(bob());
+  await type(
+    "Barcelona Guide{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Enter}{Tab}Sagrada Familia{Escape}"
+  );
+  await publishViaChip();
+  cleanup();
+
+  window.history.pushState({}, "", "/");
+  renderApp(alice());
+  await type("https://www.wikidata.org/wiki/Q1492{Escape}");
+
+  await expectTree(`
+https://www.wikidata.org/wiki/Q1492
+  [OI] Barcelona Guide ↩
+  `);
+});
+
+test("the pulled reference surfaces in the pane that pulled it", async () => {
+  const [alice, bob] = setup([ALICE, BOB]);
+
+  renderApp(bob());
+  await type(
+    "Barcelona Guide{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Enter}{Tab}Sagrada Familia{Escape}"
+  );
+  await publishViaChip();
+  cleanup();
+
+  window.history.pushState({}, "", "/");
+  renderApp(alice());
+  await type(
+    "Trip Notes{Enter}{Tab}https://www.wikidata.org/wiki/Q1492{Escape}"
+  );
+
+  await expectTree(`
+Trip Notes
+  [R] https://www.wikidata.org/wiki/Q1492
+  [OI] Barcelona Guide ↩
+  `);
+
+  await userEvent.click(await screen.findByLabelText("Barcelona Guide ↩"));
+  await userEvent.keyboard("!");
+
+  await expectTree(`
+Trip Notes
+  [R] https://www.wikidata.org/wiki/Q1492
+  [OR] Barcelona Guide
+  `);
+});
 
 test("the subscription follows attention: entity tags on open, dropped on close", async () => {
   const [alice] = setup([ALICE]);

--- a/src/attentionPull.tsx
+++ b/src/attentionPull.tsx
@@ -11,6 +11,7 @@ import { usePaneTreeResult } from "./editor/TreeView";
 import { documentKeyOf, Document } from "./core/Document";
 import { KIND_KNOWLEDGE_DEPOSIT } from "./nostr";
 import { depositEntityTags } from "./nodesDocumentEvent";
+import { isCanonicalId } from "./core/entityRecognition";
 import { useRelaysToCreatePlan } from "./relays";
 import { getReadRelays, uniqueRelayUrls } from "./relayUtils";
 
@@ -71,14 +72,19 @@ export function usePaneAttentionPull(): void {
   const rootRow = treeResult?.rows.first(undefined);
   const docId = rootRow?.node.docId;
   const sourceId = rootRow?.sourceId;
+  const rootId = rootRow?.node.id;
   const tagsKey = useMemo(() => {
-    if (!docId || !sourceId) return "";
-    const document = documents.get(documentKeyOf(sourceId, docId));
-    if (!document) return "";
-    return [...new Set(pullTagsForDocument(knowledgeDBs, document))]
-      .sort()
-      .join(" ");
-  }, [docId, sourceId, documents, knowledgeDBs]);
+    if (docId && sourceId) {
+      const document = documents.get(documentKeyOf(sourceId, docId));
+      if (!document) return "";
+      return [...new Set(pullTagsForDocument(knowledgeDBs, document))]
+        .sort()
+        .join(" ");
+    }
+    // The computed pin (E6): a document-less canonical root is the
+    // degenerate one-tag pane.
+    return rootId && isCanonicalId(rootId) ? rootId : "";
+  }, [docId, sourceId, rootId, documents, knowledgeDBs]);
 
   const relaysKey = useMemo(
     () =>

--- a/src/attentionPull.tsx
+++ b/src/attentionPull.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo } from "react";
+import { Event, UnsignedEvent } from "nostr-tools";
+import { useBackend } from "./BackendContext";
+import { useData } from "./DataContext";
+import {
+  useDocumentKnowledgeDBs,
+  useDocuments,
+  useDocumentStore,
+} from "./DocumentStore";
+import { usePaneTreeResult } from "./editor/TreeView";
+import { documentKeyOf, Document } from "./core/Document";
+import { KIND_KNOWLEDGE_DEPOSIT } from "./nostr";
+import { depositEntityTags } from "./nodesDocumentEvent";
+import { useRelaysToCreatePlan } from "./relays";
+import { getReadRelays, uniqueRelayUrls } from "./relayUtils";
+
+// Attention-driven pull (CP4): opening a document subscribes deposits
+// (34774) for that document's tags — its roots, its granted entities, and
+// the entity ids its rows link to. Results stream into the footers while
+// you look; the subscription drops on close. No standing queries: you
+// cannot look at more documents than you can look at.
+
+// PoW filtering on entity tags starts at zero (a config constant, not a
+// policy) — raise it when spam arrives, not before.
+export const PULL_ENTITY_POW_MIN = 0;
+
+function leadingZeroBits(hex: string): number {
+  const chars = hex.split("");
+  const firstNonZero = chars.findIndex((c) => c !== "0");
+  if (firstNonZero === -1) {
+    return chars.length * 4;
+  }
+  const nibble = parseInt(chars[firstNonZero], 16);
+  if (Number.isNaN(nibble)) {
+    return firstNonZero * 4;
+  }
+  return firstNonZero * 4 + Math.clz32(nibble) - 28;
+}
+
+function passesPow(event: Event | UnsignedEvent): boolean {
+  if (PULL_ENTITY_POW_MIN === 0) return true;
+  const { id } = event as Event;
+  return id !== undefined && leadingZeroBits(id) >= PULL_ENTITY_POW_MIN;
+}
+
+// The tags a document's attention justifies: exactly the set its own
+// deposit would carry — roots, granted entities, referenced entities.
+export function pullTagsForDocument(
+  knowledgeDBs: KnowledgeDBs,
+  document: Document
+): string[] {
+  return depositEntityTags(
+    document,
+    knowledgeDBs.get(document.sourceId)?.nodes
+  );
+}
+
+export function usePaneAttentionPull(): void {
+  const backend = useBackend();
+  const data = useData();
+  const store = useDocumentStore();
+  const documents = useDocuments();
+  const knowledgeDBs = useDocumentKnowledgeDBs();
+  const treeResult = usePaneTreeResult();
+  const relays = useRelaysToCreatePlan();
+  const myPubkey = data.user?.publicKey;
+  const addDepositEvents = store?.addDepositEvents;
+
+  // The pane's document is what the pane RENDERS: the tree's root row
+  // carries its docId — pane fields don't.
+  const rootRow = treeResult?.rows.first(undefined);
+  const docId = rootRow?.node.docId;
+  const sourceId = rootRow?.sourceId;
+  const tagsKey = useMemo(() => {
+    if (!docId || !sourceId) return "";
+    const document = documents.get(documentKeyOf(sourceId, docId));
+    if (!document) return "";
+    return [...new Set(pullTagsForDocument(knowledgeDBs, document))]
+      .sort()
+      .join(" ");
+  }, [docId, sourceId, documents, knowledgeDBs]);
+
+  const relaysKey = useMemo(
+    () =>
+      uniqueRelayUrls(
+        getReadRelays([...relays.defaultRelays, ...relays.userRelays])
+      ).join(" "),
+    [relays]
+  );
+
+  useEffect(() => {
+    const tags = tagsKey === "" ? [] : tagsKey.split(" ");
+    const relayUrls = relaysKey === "" ? [] : relaysKey.split(" ");
+    if (!addDepositEvents || tags.length === 0 || relayUrls.length === 0) {
+      return undefined;
+    }
+    const sub = backend.subscribe(
+      relayUrls,
+      [{ kinds: [KIND_KNOWLEDGE_DEPOSIT], "#S": tags }],
+      {
+        onevent: (event: Event): void => {
+          if (event.kind !== KIND_KNOWLEDGE_DEPOSIT) return;
+          // Own deposits are already local truth.
+          if (myPubkey && event.pubkey === myPubkey) return;
+          if (!passesPow(event)) return;
+          addDepositEvents([event]);
+        },
+      }
+    );
+    return () => sub.close();
+  }, [backend, addDepositEvents, myPubkey, tagsKey, relaysKey]);
+}
+
+export function PaneAttentionPull(): JSX.Element | null {
+  usePaneAttentionPull();
+  return null;
+}

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -14,7 +14,11 @@ import {
   documentKeyOf,
   workspaceDocumentKey,
 } from "./Document";
-import { entityIdForText, isCanonicalId } from "./entityRecognition";
+import {
+  entityIdForText,
+  ENTITY_SCHEME_RE,
+  isCanonicalId,
+} from "./entityRecognition";
 import { icalFeedLinkText, isBareIcalFeedUrl } from "./ical";
 import { documentLinkHref } from "./linkPath";
 import { getWorkspaceNode, withWorkspace, workspaceOf } from "./knowledge";
@@ -626,6 +630,20 @@ export function planMaterializeComputedRow<T extends GraphPlan>(
   }
   const parentNode = getWorkspaceNode(plan.knowledgeDBs, parentID);
   if (!parentNode) {
+    // First write on the computed pin mints the entity's document (E6):
+    // a placement needs a file, so the mint rides the gesture. Entity
+    // schemes only — calendar entries materialize through their host.
+    if (ENTITY_SCHEME_RE.test(parentID)) {
+      const minted = withDocumentRoot(
+        newGraphNode(plainSpans(parentID), { uuid: parentID })
+      );
+      return planMaterializeComputedRow(
+        planUpsertNodes(plan, minted),
+        row,
+        metadata,
+        placement
+      );
+    }
     const { host } = row.materialize;
     if (!host) {
       return [plan, row.node, false];

--- a/src/editor/Workspace.tsx
+++ b/src/editor/Workspace.tsx
@@ -28,6 +28,7 @@ import {
 } from "../SplitPanesContext";
 import { useNavigationState } from "../NavigationStateContext";
 import { usePaneHistory } from "../PaneHistoryContext";
+import { PaneAttentionPull } from "../attentionPull";
 import {
   PaneTreeResultProvider,
   TreeView,
@@ -1930,6 +1931,7 @@ export function PaneView(): JSX.Element | null {
   return (
     <TemporaryViewProvider>
       <PaneTreeResultProvider>
+        <PaneAttentionPull />
         <PaneViewInner />
       </PaneTreeResultProvider>
     </TemporaryViewProvider>

--- a/src/editor/linkOperations.ts
+++ b/src/editor/linkOperations.ts
@@ -109,7 +109,16 @@ function nodeTarget(
   const target =
     mode === "target" ? source : resolveBlockLinkTarget(graph, source);
   if (!target) {
-    return calendarEntryFallbackTarget(data, link.targetID);
+    const calendarTarget = calendarEntryFallbackTarget(data, link.targetID);
+    if (calendarTarget) {
+      return calendarTarget;
+    }
+    // Entity links resolve to the ordinary node view even without a
+    // local page — the computed pin (E6).
+    if (ENTITY_SCHEME_RE.test(link.targetID)) {
+      return { sourceId: LOCAL, rootNodeId: link.targetID };
+    }
+    return undefined;
   }
   const parent = target.node.parent
     ? getNodeInSource(graph, {

--- a/src/nodesDocumentEvent.ts
+++ b/src/nodesDocumentEvent.ts
@@ -1,4 +1,5 @@
 import { UnsignedEvent } from "nostr-tools";
+import type { Map as ImmutableMap } from "immutable";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import type { Document } from "./core/Document";
@@ -53,9 +54,50 @@ export function buildDocumentEvent(
 // The S set is {own roots} ∪ knowstr_publish.entities (interop rule: tags
 // and content sit inside one signature and MUST agree). Roots stay implicit
 // in the frontmatter; entities is the carried record of granted audiences.
-export function depositEntityTags(document: Document): string[] {
+const ENTITY_ID_PATTERN = /^(wd|asset|ical):/;
+
+// The real-world entities a document references: every wd:/asset:/ical:
+// link target reachable from its roots, block or inline. These join the
+// deposit's S-tags — the wire spec's "entities" — so two strangers
+// referencing the same entity rendezvous through it.
+export function referencedEntityIds(
+  nodes: ImmutableMap<string, GraphNode> | undefined,
+  topNodeShortIds: ReadonlyArray<string>
+): string[] {
+  if (!nodes) return [];
+  const seen = new Set<string>();
+  const linked = new Set<string>();
+  const visit = (id: string): void => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    const node = nodes.get(id);
+    if (!node) return;
+    node.spans.forEach((span) => {
+      if (
+        span.kind === "link" &&
+        ENTITY_ID_PATTERN.test(String(span.targetID))
+      ) {
+        linked.add(String(span.targetID));
+      }
+    });
+    node.children.forEach((childId) => visit(String(childId)));
+  };
+  topNodeShortIds.forEach(visit);
+  return [...linked];
+}
+
+export function depositEntityTags(
+  document: Document,
+  nodes?: ImmutableMap<string, GraphNode>
+): string[] {
   const entities = publishStateOf(document.frontMatter)?.entities ?? [];
-  return [...new Set([...document.topNodeShortIds, ...entities])];
+  return [
+    ...new Set([
+      ...document.topNodeShortIds,
+      ...entities,
+      ...referencedEntityIds(nodes, document.topNodeShortIds),
+    ]),
+  ];
 }
 
 // Whether any tag involves an asset entity. Ladder rungs are space-joined
@@ -70,7 +112,8 @@ export function hasAssetEntityTag(tags: string[]): boolean {
 export function buildDepositEvent(
   document: Document,
   pubkey: PublicKey,
-  content: string
+  content: string,
+  nodes?: ImmutableMap<string, GraphNode>
 ): UnsignedEvent {
   const systemRoleTags = document.systemRole
     ? ([["s", document.systemRole]] as string[][])
@@ -81,7 +124,7 @@ export function buildDepositEvent(
     created_at: newTimestamp(),
     tags: [
       ["d", document.docId],
-      ...depositEntityTags(document).map((id) => ["S", id]),
+      ...depositEntityTags(document, nodes).map((id) => ["S", id]),
       ...systemRoleTags,
       msTag(),
     ],

--- a/src/nostrEvents.ts
+++ b/src/nostrEvents.ts
@@ -2,7 +2,11 @@ import { Collection, List } from "immutable";
 import { Event, EventTemplate, Filter, UnsignedEvent } from "nostr-tools";
 import type { DocumentDelete, ParsedDocument } from "./core/Document";
 import { parseToDocument } from "./core/Document";
-import { KIND_DELETE, KIND_KNOWLEDGE_DOCUMENT } from "./nostr";
+import {
+  KIND_DELETE,
+  KIND_KNOWLEDGE_DOCUMENT,
+  KIND_KNOWLEDGE_DEPOSIT,
+} from "./nostr";
 
 export function findAllTags(
   event: EventTemplate,
@@ -88,6 +92,23 @@ export function eventToParsed(
     document: storageKey ? { ...parsed.document, storageKey } : parsed.document,
     nodes: parsed.nodes,
   };
+}
+
+// A deposit (34774) is a published document: plaintext markdown, entity
+// S-tags for routing, replaceable per (pubkey, d). Parsed exactly like a
+// document event, under the depositor's own source id — a read-only
+// foreign source, never merged with anyone else's.
+export function depositToParsed(
+  event: Event | UnsignedEvent
+): ParsedDocument | undefined {
+  if (event.kind !== KIND_KNOWLEDGE_DEPOSIT) return undefined;
+  const dTag = findTag(event, "d");
+  if (!dTag) return undefined;
+  const parsed = parseToDocument(event.pubkey as PublicKey, event.content, {
+    updatedMsOverride: getEventMs(event),
+    docIdFallback: dTag,
+  });
+  return { document: parsed.document, nodes: parsed.nodes };
 }
 
 export function eventToDocumentDelete(

--- a/src/planner.tsx
+++ b/src/planner.tsx
@@ -792,7 +792,12 @@ function depositEventFor(
   const publishState = publishStateOf(write.document.frontMatter);
   return publishState && !publishState.paused
     ? ({
-        ...buildDepositEvent(write.document, pubkey, write.content),
+        ...buildDepositEvent(
+          write.document,
+          pubkey,
+          write.content,
+          plan.knowledgeDBs.get(LOCAL)?.nodes
+        ),
         writeRelayConf: depositWriteRelayConf(
           write.document,
           plan.relays.userRelays

--- a/src/semanticProjection.ts
+++ b/src/semanticProjection.ts
@@ -7,6 +7,7 @@ import {
   itemPassesFilters,
   getSemanticID,
   getNodeContext,
+  getNodeSemanticID,
   getNodeText,
   getNode,
   resolveNode,
@@ -160,11 +161,16 @@ export function findRefsToNode(
     .toList();
 }
 
+// The key carries the owner's own title beside its ancestor context:
+// ancestors alone collapse every root-level document into one group, and
+// the local ref then shadows the stranger's (CP4.4).
 function getRefContextKey(
-  _knowledgeDBs: KnowledgeDBs,
+  knowledgeDBs: KnowledgeDBs,
   ref: ReferencedByRef
 ): string {
-  return getContextKey(ref.context);
+  const node = getNode(knowledgeDBs, ref.nodeID, ref.sourceId);
+  const semantic = node ? getNodeSemanticID(node) : ref.nodeID;
+  return getContextKey(ref.context.push(semantic));
 }
 
 function contextKeyForCref(
@@ -181,7 +187,9 @@ function contextKeyForCref(
     return undefined;
   }
   return getContextKey(
-    getNodeContext(knowledgeDBs, targetNode, effectiveAuthor)
+    getNodeContext(knowledgeDBs, targetNode, effectiveAuthor).push(
+      getNodeSemanticID(targetNode)
+    )
   );
 }
 
@@ -380,18 +388,9 @@ export function getIncomingCrefsForNode(
   const { graphIndex, knowledgeDBs } = graph;
   const current = currentItems || List<GraphNode>();
 
-  const graphLinkRefs = (() => {
-    if (!currentNodeID) {
-      return [];
-    }
-    const sourceScopedRefs =
-      graphIndex.incomingCrefsByTarget.get(
-        nodeRefKey({ sourceId: itemsSourceId, id: currentNodeID })
-      ) ?? [];
-    return sourceScopedRefs.length > 0
-      ? sourceScopedRefs
-      : graphIndex.incomingCrefs.get(currentNodeID) ?? [];
-  })();
+  const graphLinkRefs = currentNodeID
+    ? graphIndex.incomingCrefs.get(currentNodeID) ?? []
+    : [];
   const graphLinkSourceNodes = graphLinkRefs
     .map((ref) => getGraphLinkOwner(graph, ref))
     .filter((node): node is ResolvedNode => node !== undefined);

--- a/src/treeTraversal.ts
+++ b/src/treeTraversal.ts
@@ -964,7 +964,13 @@ function getChildrenForRegularNode(
   );
 
   const containingNodeID = parentRow.parentNode?.id;
-  const visibleAuthors = ImmutableSet<SourceId>([LOCAL, author, nodeSourceId]);
+  // Pulled deposit authors are deliberately visible: pull follows
+  // attention, so what arrived was asked for (CP4).
+  const visibleAuthors = ImmutableSet<SourceId>([
+    LOCAL,
+    author,
+    nodeSourceId,
+  ]).union(ImmutableSet<SourceId>(data.pulledAuthors ?? []));
 
   const incomingCrefs = getIncomingCrefsForNode(
     graph,

--- a/src/treeTraversal.ts
+++ b/src/treeTraversal.ts
@@ -1,5 +1,6 @@
 import { List, Map, Set as ImmutableSet } from "immutable";
-import { LOCAL } from "./core/nodeRef";
+import { LOCAL, nodeRefKey } from "./core/nodeRef";
+import { referencedEntityIds } from "./nodesDocumentEvent";
 import {
   ViewPath,
   addNodeToPathWithNodes,
@@ -972,7 +973,7 @@ function getChildrenForRegularNode(
     nodeSourceId,
   ]).union(ImmutableSet<SourceId>(data.pulledAuthors ?? []));
 
-  const incomingCrefs = getIncomingCrefsForNode(
+  const ownCrefs = getIncomingCrefsForNode(
     graph,
     visibleAuthors,
     containingNodeID,
@@ -982,7 +983,46 @@ function getChildrenForRegularNode(
     allChildNodes,
     undefined,
     data.documents
-  ).filter((ref) => ref.id !== nodes.id);
+  );
+
+  // The pane that pulled renders: refs into the document's referenced
+  // entities surface at its root, pulled sources only — local backlinks
+  // stay on the entity page (CP4.4).
+  const pulledSet = ImmutableSet<SourceId>(data.pulledAuthors ?? []);
+  const contextEntityIds =
+    containingNodeID === undefined && !pulledSet.isEmpty()
+      ? List(
+          referencedEntityIds(graph.knowledgeDBs.get(nodeSourceId)?.nodes, [
+            nodes.id,
+          ])
+        ).filter((entityId) => entityId !== nodes.id)
+      : List<string>();
+  const contextCrefs = contextEntityIds.flatMap((entityId) =>
+    getIncomingCrefsForNode(
+      graph,
+      visibleAuthors,
+      containingNodeID,
+      entityId,
+      author,
+      nodeSourceId,
+      allChildNodes,
+      undefined,
+      data.documents
+    ).filter((ref) => pulledSet.has(ref.sourceId))
+  );
+
+  const seenRefKeys = new Set<string>();
+  const incomingCrefs = ownCrefs
+    .concat(contextCrefs)
+    .filter((ref) => {
+      const key = nodeRefKey(ref);
+      if (seenRefKeys.has(key)) {
+        return false;
+      }
+      seenRefKeys.add(key);
+      return true;
+    })
+    .filter((ref) => ref.id !== nodes.id);
 
   const visibleIncomingCrefs = activeFilters.includes("incoming")
     ? incomingCrefs

--- a/src/treeTraversal.ts
+++ b/src/treeTraversal.ts
@@ -41,7 +41,7 @@ import {
   icalFeedUrlOf,
   mergeProjectedEntries,
 } from "./core/ical";
-import { canonicalTargetOf } from "./core/entityRecognition";
+import { canonicalTargetOf, ENTITY_SCHEME_RE } from "./core/entityRecognition";
 import {
   documentKeyOf,
   documentLinkPath,
@@ -297,10 +297,22 @@ function resolveRowForPath(
     })?.node;
   })();
   const resolved = lookupNode(graph, rowID, paneSourceId);
+  // The entity surface: a dangling canonical id at the pane root renders
+  // as a computed pin — nothing stored until the first write mints (E6).
   const node =
     edgeNode ??
     resolved?.node ??
-    (rowID === EMPTY_SEMANTIC_ID ? emptyRootNode() : undefined);
+    (rowID === EMPTY_SEMANTIC_ID ? emptyRootNode() : undefined) ??
+    (segments.length === 1 && ENTITY_SCHEME_RE.test(rowID)
+      ? {
+          children: List<ID>(),
+          id: rowID,
+          spans: plainSpans(rowID),
+          updated: Date.now(),
+          root: rowID,
+          relevance: undefined,
+        }
+      : undefined);
   if (!node) {
     return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,9 @@ declare global {
 
     views: Views;
     panes: Pane[];
+    // Authors of attention-pulled deposits (CP4): their versions and
+    // suggestions are deliberately visible — pulled is chosen.
+    pulledAuthors?: ReadonlyArray<SourceId>;
   };
 
   type LocalStorage = {


### PR DESCRIPTION
Following an entity link is mint-or-link's read half: with a home you land in it; without one the pane addresses the bare id and renders a **computed pin** — nothing stored, nothing listed; browse ten entity pages and keep none. The dangling pane is the degenerate one-tag pane (CP4.4): its attention pull subscribes exactly the entity tag, so `↩` references and backlinks fill the footers while it is open. The **first write gesture mints** the document rooted at the entity id — a placement needs a file, so the mint rides the gesture (Roam's mention-as-page UX without their orphan-page residue; spec: implementation.md E6). Entity schemes only: dangling calendar-entry links keep opening their carrying calendar (regression caught by CalendarProjection and pinned).

Note on the diff: this branch stacks on `f/cp4-3-attention-pull` (CP4.3 transport + CP4.4 surfacing), so the compare against master shows those commits beneath. The E6 change itself is the last commit (a5cf113). Say the word and I retarget the PR base to `f/cp4-3-attention-pull` for an isolated E6 diff.